### PR TITLE
Add version numbers in setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["setuptools >= 59.0", "setuptools_scm", "wheel"]
+requires = [
+    "setuptools >= 59.0",
+    "setuptools_scm",
+    "toml >= 0.10.2",
+    "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,5 @@ setup(
     description="CLP FFI Python Interface",
     ext_modules=[ir],
     packages=["clp_ffi_py"],
+    version="0.0.1"
 )

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,19 @@
 import os
+import sys
+import toml
 from setuptools import setup, Extension
+from typing import Any, Dict, Optional
 
 ir: Extension = Extension(
     name="clp_ffi_py.ir",
     language="c++",
-    include_dirs=[
-        "src"
-    ],
+    include_dirs=["src"],
     sources=[
         "src/clp/components/core/src/ffi/ir_stream/decoding_methods.cpp",
         "src/clp/components/core/src/ffi/ir_stream/encoding_methods.cpp",
         "src/clp/components/core/src/ffi/encoding_methods.cpp",
         "src/clp/components/core/src/string_utils.cpp",
         "src/clp/components/core/src/TraceableException.cpp",
-
         "src/clp_ffi_py/ir/encoding_methods.cpp",
         "src/clp_ffi_py/ir/Metadata.cpp",
         "src/clp_ffi_py/ir/PyFourByteEncoder.cpp",
@@ -24,18 +24,31 @@ ir: Extension = Extension(
         "src/clp_ffi_py/utils.cpp",
     ],
     extra_compile_args=[
-        '-std=c++17',
+        "-std=c++17",
         "-O3",
     ],
-    define_macros=[
-        ("SOURCE_PATH_SIZE", str(len(os.path.abspath("./src/clp/components/core"))))
-    ]
+    define_macros=[("SOURCE_PATH_SIZE", str(len(os.path.abspath("./src/clp/components/core"))))],
 )
 
-setup(
-    name="clp_ffi_py",
-    description="CLP FFI Python Interface",
-    ext_modules=[ir],
-    packages=["clp_ffi_py"],
-    version="0.0.1"
-)
+if "__main__" == __name__:
+    try:
+        if hasattr(os, "sys") and "darwin" == os.sys.platform:
+            target: Optional[str] = os.environ.get("MACOSX_DEPLOYMENT_TARGET")
+            if None is target or float(target) < 10.15:
+                os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"
+
+        config: Dict[str, Any] = toml.load("pyproject.toml")
+        version: Optional[str] = config.get("project", {}).get("version", None)
+        if None is version:
+            sys.exit("Error: The version number is not found in pyproject.toml")
+
+        setup(
+            name="clp_ffi_py",
+            description="CLP FFI Python Interface",
+            ext_modules=[ir],
+            packages=["clp_ffi_py"],
+            version=version,
+        )
+
+    except Exception as e:
+        sys.exit(f"Error: {e}")

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 import toml
 from setuptools import setup, Extension
@@ -32,7 +33,7 @@ ir: Extension = Extension(
 
 if "__main__" == __name__:
     try:
-        if hasattr(os, "sys") and "darwin" == os.sys.platform:
+        if "Darwin" == platform.system():
             target: Optional[str] = os.environ.get("MACOSX_DEPLOYMENT_TARGET")
             if None is target or float(target) < 10.15:
                 os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if "__main__" == __name__:
         config: Dict[str, Any] = toml.load("pyproject.toml")
         version: Optional[str] = config.get("project", {}).get("version", None)
         if None is version:
-            sys.exit("Error: The version number is not found in pyproject.toml")
+            sys.exit("Error: The version number was not found in pyproject.toml")
 
         setup(
             name="clp_ffi_py",


### PR DESCRIPTION
# Description
The version number must be properly added to the `setup.py` so that Python3.6 wheel can be built properly by `cibuildwheel`. Ideally, with this change added we will no longer need to build for Python3.6 manually.
In addition, this PR also automates the build environment setup when building for macOS. By default, most of macOS environment has `MACOSX_DEPLOYMENT_TARGET ` set to `10.13`, which does not support c++17 compilation. With this PR, the build tool will automatically set `MACOSX_DEPLOYMENT_TARGET ` to `10.15` (the minimum requirement to build c++17 features) if the default version doesn't support c++17.

