### PR TITLE
Add more details on README to show examples of how to use readers for decoding and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,27 +44,15 @@ CLP IR Readers provide a convenient interface for CLP IR decoding and search met
 
 - Simple wrapper around CLPIRStreamHandler that calls open with a given local path.
 
-### Example Code: Using CLPIRFileReader
+### Example Code: Using CLPIRFileReader to iterate and print log events
 ```python
 from pathlib import Path
-from typing import Dict, List
-
-from clp_ffi_py import LogEvent
 from clp_ffi_py.readers import CLPIRFileReader
-
-# A list to store all the log events in `example.clp.zst`
-log_events: List[LogEvent] = []
-# A dictionary to record each timestamp and its corresponding log message count
-log_event_counts_by_timestamp: Dict[int, int] = {}
 
 with CLPIRFileReader(Path("example.clp.zst")) as clp_reader:
     for log_event in clp_reader:
-        log_events.append(log_event)
-        timestamp: int = log_event.get_timestamp()
-        if timestamp in log_event_counts_by_timestamp:
-            log_event_counts_by_timestamp[timestamp] += 1
-        else:
-            log_event_counts_by_timestamp[timestamp] = 0
+        # Print the log message with its timestamp properly formatted.
+        print(log_event.get_formatted_message())
 ```
 Each log event is represented by an `LogEvent` object, which offers methods to retrieve its
 underlying details such as timestamp and log message. For more information, refer to the 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ python -m build
 
 CLP IR Readers provide a convenient interface for CLP IR decoding and search methods.
 
-### CLPIRStreamReader
+### ClpIrStreamReader
 
 - Read/decode any arbitrary CLP IR stream (as an instance of `IO[bytes]`).
 - Can be used as an iterator that returns each log event as a `LogEvent` object.
@@ -40,20 +40,22 @@ CLP IR Readers provide a convenient interface for CLP IR decoding and search met
   - Searching log events within a certain time range.
   - Searching log messages that match certain wildcard queries.
 
-### CLPIRFileReader
+### ClpIrFileReader
 
 - Simple wrapper around CLPIRStreamHandler that calls `open` with a given local path.
 
-### Example Code: Using CLPIRFileReader to iterate and print log events
+### Example Code: Using ClpIrFileReader to iterate and print log events
+
 ```python
 from pathlib import Path
-from clp_ffi_py.readers import CLPIRFileReader
+from clp_ffi_py.readers import ClpIrFileReader
 
-with CLPIRFileReader(Path("example.clp.zst")) as clp_reader:
+with ClpIrFileReader(Path("example.clp.zst")) as clp_reader:
     for log_event in clp_reader:
         # Print the log message with its timestamp properly formatted.
         print(log_event.get_formatted_message())
 ```
+
 Each log event is represented by a `LogEvent` object, which offers methods to retrieve its
 underlying details, such as the timestamp and the log message. For more information, use
 the following code to see all the available methods and the associated docstring.
@@ -64,12 +66,13 @@ help(LogEvent)
 ```
 
 ### Example Code: Using Query to search log events by specifying a certain time range
+
 ```python
 from pathlib import Path
 from typing import List
 
 from clp_ffi_py import LogEvent, Query
-from clp_ffi_py.readers import CLPIRFileReader
+from clp_ffi_py.readers import ClpIrFileReader
 
 # Create a search query that specifies a time range by UNIX epoch timestamp in
 # milliseconds. It will search from 2016.Nov.28 21:00 to 2016.Nov.29 3:00.
@@ -80,18 +83,19 @@ time_range_query: Query = Query(
 # A list to store all the log events within the search time range
 log_events: List[LogEvent] = []
 
-with CLPIRFileReader(Path("example.clp.zst")) as clp_reader:
+with ClpIrFileReader(Path("example.clp.zst")) as clp_reader:
     for log_event in clp_reader.search(time_range_query):
         log_events.append(log_event)
 ```
 
 ### Example Code: Using Query to search log messages of certain pattern(s) specified by wildcard queries.
+
 ```python
 from pathlib import Path
 from typing import List, Tuple
 
 from clp_ffi_py import Query, WildcardQuery
-from clp_ffi_py.readers import CLPIRFileReader
+from clp_ffi_py.readers import ClpIrFileReader
 
 # Generate a list of wildcard patterns to filter log messages:
 wildcard_query_list: List[WildcardQuery] = [
@@ -104,18 +108,22 @@ wildcard_search_query: Query = Query(wildcard_queries=wildcard_query_list)
 # [timestamp, message]
 matched_log_messages: List[Tuple[int, str]] = []
 
-with CLPIRFileReader(Path("example.clp.zst")) as clp_reader:
+with ClpIrFileReader(Path("example.clp.zst")) as clp_reader:
     for log_event in clp_reader.search(wildcard_search_query):
         matched_log_messages.append((log_event.get_timestamp(), log_event.get_log_message()))
 ```
+
 A `Query` object may have both the search time range and the wildcard queries specified to support
 more complex search scenarios. For more details, use the following code to access the related
 docstring.
+
 ```python
 from clp_ffi_py import Query
 help(Query)
 ```
+
 ### Parallelization
+
 The `Query` and `LogEvent` classes can be serialized by [pickle][15]. Therefore, decoding and search
 can be parallelized across streams/files using libraries such as [multiprocessing][13] and [tqlm][14].
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ CLP IR Readers provide a convenient interface for CLP IR decoding and search met
 
 ### CLPIRFileReader
 
-- Simple wrapper around CLPIRStreamHandler that calls open with a given local path.
+- Simple wrapper around CLPIRStreamHandler that calls `open` with a given local path.
 
 ### Example Code: Using CLPIRFileReader
 ```python
@@ -66,9 +66,9 @@ with CLPIRFileReader(Path("example.clp.zst")) as clp_reader:
         else:
             log_event_counts_by_timestamp[timestamp] = 0
 ```
-Each log event is represented by an `LogEvent` object, which offers methods to retrieve its
-underlying details such as timestamp and log message. For more information, refer to the 
-docstring of `LogEvent`.
+Each log event is represented by a `LogEvent` object, which offers methods to retrieve its
+underlying details, such as the timestamp and the log message. For more information, refer
+to the docstring of `LogEvent`.
 
 ### Example Code: Using Query to search log events by specifying a certain time range
 ```python
@@ -102,7 +102,7 @@ from clp_ffi_py.readers import CLPIRFileReader
 
 # Generate a list of wildcard patterns to filter log messages:
 wildcard_query_list: List[WildcardQuery] = [
-    WildcardQuery("*uid=*,state=failed*"),
+    WildcardQuery("*uid=*,status=failed*"),
     WildcardQuery("*UID=*,Status=KILLED*", case_sensitive=True),
 ]
 # Initialize a Query object with the list of wildcard patterns:

--- a/README.md
+++ b/README.md
@@ -55,8 +55,13 @@ with CLPIRFileReader(Path("example.clp.zst")) as clp_reader:
         print(log_event.get_formatted_message())
 ```
 Each log event is represented by a `LogEvent` object, which offers methods to retrieve its
-underlying details, such as the timestamp and the log message. For more information, refer
-to the docstring of `LogEvent`.
+underlying details, such as the timestamp and the log message. For more information, use
+the following code to see all the available methods and the associated docstring.
+
+```python
+from clp_ffi_py import LogEvent
+help(LogEvent)
+```
 
 ### Example Code: Using Query to search log events by specifying a certain time range
 ```python
@@ -66,8 +71,8 @@ from typing import List
 from clp_ffi_py import LogEvent, Query
 from clp_ffi_py.readers import CLPIRFileReader
 
-# Create a search query that specifies a time range by UNIX epoch timestamp.
-# It will search from 2016.Nov.28 21:00 to 2016.Nov.29 3:00
+# Create a search query that specifies a time range by UNIX epoch timestamp in
+# milliseconds. It will search from 2016.Nov.28 21:00 to 2016.Nov.29 3:00.
 time_range_query: Query = Query(
     search_time_lower_bound=1480366800000,  # 2016.11.28 21:00
     search_time_upper_bound=1480388400000,  # 2016.11.29 03:00
@@ -104,7 +109,15 @@ with CLPIRFileReader(Path("example.clp.zst")) as clp_reader:
         matched_log_messages.append((log_event.get_timestamp(), log_event.get_log_message()))
 ```
 A `Query` object may have both the search time range and the wildcard queries specified to support
-more complex search scenarios. For more details, refer to the docstring of `Query`.
+more complex search scenarios. For more details, use the following code to access the related
+docstring.
+```python
+from clp_ffi_py import Query
+help(Query)
+```
+### Parallelization
+The `Query` and `LogEvent` classes can be serialized by [pickle][15]. Therefore, decoding and search
+can be parallelized across streams/files using libraries such as [multiprocessing][13] and [tqlm][14].
 
 ## Testing
 
@@ -194,3 +207,6 @@ using `pip`. Developers need to install them using other package management tool
 [10]: https://beta.ruff.rs/docs/
 [11]: https://docformatter.readthedocs.io/en/latest/
 [12]: https://docformatter.readthedocs.io/en/latest/faq.html#interaction-with-black
+[13]: https://docs.python.org/3/library/multiprocessing.html
+[14]: https://tqdm.github.io/
+[15]: https://docs.python.org/3/library/pickle.html

--- a/clp_ffi_py/readers.py
+++ b/clp_ffi_py/readers.py
@@ -8,7 +8,7 @@ from zstandard import ZstdDecompressionReader, ZstdDecompressor
 from clp_ffi_py import Decoder, DecoderBuffer, LogEvent, Metadata, Query
 
 
-class CLPIRStreamReader:
+class ClpIrStreamReader:
     """
     This class represents a stream reader used to read/decode encoded log events
     from a CLP IR stream. It also provides method(s) to instantiate a log event
@@ -115,15 +115,15 @@ class CLPIRStreamReader:
         self.close()
 
 
-class CLPIRFileReader(CLPIRStreamReader):
+class ClpIrFileReader(ClpIrStreamReader):
     """
-    Wrapper class of `CLPIRStreamReader` that calls `open` for convenience.
+    Wrapper class of `ClpIrStreamReader` that calls `open` for convenience.
     """
 
     def __init__(
         self,
         fpath: Path,
-        decoder_buffer_size: int = CLPIRStreamReader.DEFAULT_DECODER_BUFFER_SIZE,
+        decoder_buffer_size: int = ClpIrStreamReader.DEFAULT_DECODER_BUFFER_SIZE,
         enable_compression: bool = True,
     ):
         self._path: Path = fpath

--- a/tests/test_ir/test_readers.py
+++ b/tests/test_ir/test_readers.py
@@ -9,7 +9,7 @@ from test_ir.test_decoder import (
 )
 
 from clp_ffi_py import LogEvent, Metadata, Query
-from clp_ffi_py.readers import CLPIRStreamReader
+from clp_ffi_py.readers import ClpIrStreamReader
 
 
 def read_log_stream(
@@ -18,7 +18,7 @@ def read_log_stream(
     metadata: Metadata
     log_events: List[LogEvent] = []
     with open(str(log_path), "rb") as fin:
-        reader = CLPIRStreamReader(fin, enable_compression=enable_compression)
+        reader = ClpIrStreamReader(fin, enable_compression=enable_compression)
         if None is query:
             for log_event in reader:
                 log_events.append(log_event)


### PR DESCRIPTION
# Description
Add explanations and simple example code to show how to use CLPIRReaders to decode and search a CLP IR stream.

