### PR TITLE
Fix auto-completion issue resulting from class up-casting

### DIFF
--- a/clp_ffi_py/readers.py
+++ b/clp_ffi_py/readers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from sys import stderr
 from types import TracebackType
@@ -8,7 +10,7 @@ from zstandard import ZstdDecompressionReader, ZstdDecompressor
 from clp_ffi_py import Decoder, DecoderBuffer, LogEvent, Metadata, Query
 
 
-class ClpIrStreamReader:
+class ClpIrStreamReader(Iterator):
     """
     This class represents a stream reader used to read/decode encoded log events
     from a CLP IR stream. It also provides method(s) to instantiate a log event
@@ -90,12 +92,12 @@ class ClpIrStreamReader:
     def close(self) -> None:
         self.__istream.close()
 
-    def __iter__(self) -> Iterator[LogEvent]:
+    def __iter__(self) -> ClpIrStreamReader[LogEvent]:
         if False is self.has_metadata():
             self.read_preamble()
         return self
 
-    def __enter__(self) -> Iterator[LogEvent]:
+    def __enter__(self) -> ClpIrStreamReader[LogEvent]:
         if False is self.has_metadata():
             self.read_preamble()
         return self

--- a/clp_ffi_py/readers.py
+++ b/clp_ffi_py/readers.py
@@ -10,7 +10,7 @@ from zstandard import ZstdDecompressionReader, ZstdDecompressor
 from clp_ffi_py import Decoder, DecoderBuffer, LogEvent, Metadata, Query
 
 
-class ClpIrStreamReader(Iterator):
+class ClpIrStreamReader(Iterator[LogEvent]):
     """
     This class represents a stream reader used to read/decode encoded log events
     from a CLP IR stream. It also provides method(s) to instantiate a log event
@@ -92,12 +92,12 @@ class ClpIrStreamReader(Iterator):
     def close(self) -> None:
         self.__istream.close()
 
-    def __iter__(self) -> ClpIrStreamReader[LogEvent]:
+    def __iter__(self) -> ClpIrStreamReader:
         if False is self.has_metadata():
             self.read_preamble()
         return self
 
-    def __enter__(self) -> ClpIrStreamReader[LogEvent]:
+    def __enter__(self) -> ClpIrStreamReader:
         if False is self.has_metadata():
             self.read_preamble()
         return self


### PR DESCRIPTION
# Description
Auto-completion of `ClpIrStreamReader` is unavailable to IDEs due to down-casting of return type specified in the `__iter__` and `__enter__` class functions. This diff restores the auto-completion functionality by modifying `ClpIrStreamReader` to inherit the `Iterator` class, then switch the return type from `Iterator[LogEvent]` to `ClpIrStreamReader[LogEvent]` type. Additionally, `from __future__ import annotations` import statement is added to ensure lower Python runtime version can recognize the `ClpIrStreamReader` return type.

# Validation performed
After modifying `Reader.py` in the 0.0.2 release, the auto-completion functionality with IDE can be used normally.
