### PR TITLE
Add support for partial matching in the wildcard query

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ from clp_ffi_py.ir import ClpIrFileReader, Query, QueryBuilder
 # Create a QueryBuilder object to build the search query.
 query_builder: QueryBuilder = QueryBuilder()
 
-# Add wildcard patterns to filter log messages:
+# Add wildcard patterns to filter log messages.By default, the partial match
+# will be executed. Please refer to the documents of `WildcardQuery` object for
+# the difference between partial and full matches.
 query_builder.add_wildcard_query("uid=*,status=failed")
 query_builder.add_wildcard_query("UID=*,Status=KILLED", case_sensitive=True)
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ from clp_ffi_py.ir import ClpIrFileReader, Query, QueryBuilder
 query_builder: QueryBuilder = QueryBuilder()
 
 # Add wildcard patterns to filter log messages:
-query_builder.add_wildcard_query("*uid=*,status=failed*")
-query_builder.add_wildcard_query("*UID=*,Status=KILLED*", case_sensitive=True)
+query_builder.add_wildcard_query("uid=*,status=failed")
+query_builder.add_wildcard_query("UID=*,Status=KILLED", case_sensitive=True)
 
 # Initialize a Query object using the builder:
 wildcard_search_query: Query = query_builder.build()

--- a/clp_ffi_py/ir/query_builder.py
+++ b/clp_ffi_py/ir/query_builder.py
@@ -78,16 +78,19 @@ class QueryBuilder:
         self._search_time_termination_margin = ts
         return self
 
-    def add_wildcard_query(self, wildcard_query: str, case_sensitive: bool = False) -> QueryBuilder:
+    def add_wildcard_query(
+        self, wildcard_query: str, case_sensitive: bool = False, partial_match: bool = True
+    ) -> QueryBuilder:
         """
         Constructs and adds a :class:`~clp_ffi_py.wildcard_query.WildcardQuery`
         to the wildcard query list.
 
         :param wildcard_query: The wildcard query string to add.
         :param case_sensitive: Whether to perform case-sensitive matching.
+        :param partial_match: Whether to perform partial matching.
         :return: self.
         """
-        self._wildcard_queries.append(WildcardQuery(wildcard_query, case_sensitive))
+        self._wildcard_queries.append(WildcardQuery(wildcard_query, case_sensitive, partial_match))
         return self
 
     def add_wildcard_queries(self, wildcard_queries: List[WildcardQuery]) -> QueryBuilder:

--- a/clp_ffi_py/wildcard_query.py
+++ b/clp_ffi_py/wildcard_query.py
@@ -1,7 +1,8 @@
 class WildcardQuery:
     """
-    This class defines a wildcard query, which includes a wildcard string and a
-    boolean value to indicate if the match is case-sensitive.
+    This class defines a wildcard query, which includes a wildcard string a
+    boolean value to indicate if the match is case-sensitive, and a boolean
+    value to indicate if the match is a partial match.
 
     A wildcard string may contain the following types of supported wildcards:
 
@@ -10,17 +11,29 @@ class WildcardQuery:
 
     Each wildcard can be escaped using a preceding '\\\\' (a single backslash).
     Other characters which are escaped are treated as normal characters.
+
+    By default, the wildcard query is set to be a partial match. This means any
+    log message that contains the given wildcard string will be a match. If the
+    partial match is set to false, the wildcard query matches only if the
+    wildcard string matches the entire log message.
+
+    A partial match wildcard query `"${WILDCARD_STRING}"` is equivalent to the
+    full match wildcard query `*${WILDCARD_STRING}*`.
     """
 
-    def __init__(self, wildcard_query: str, case_sensitive: bool = False):
+    def __init__(
+        self, wildcard_query: str, case_sensitive: bool = False, partial_match: bool = True
+    ):
         """
         Initializes a wildcard query using the given parameters.
 
         :param wildcard_query: Wildcard query string.
         :param case_sensitive: Case sensitive indicator.
+        :param partial_match: Partial match indicator.
         """
         self._wildcard_query: str = wildcard_query
         self._case_sensitive: bool = case_sensitive
+        self._partial_match: bool = partial_match
 
     def __str__(self) -> str:
         """
@@ -28,7 +41,8 @@ class WildcardQuery:
         """
         return (
             f'WildcardQuery(wildcard_query="{self._wildcard_query}",'
-            f" case_sensitive={self._case_sensitive})"
+            f" case_sensitive={self._case_sensitive}),"
+            f" partial_match={self._partial_match}"
         )
 
     def __repr__(self) -> str:
@@ -44,3 +58,7 @@ class WildcardQuery:
     @property
     def case_sensitive(self) -> bool:
         return self._case_sensitive
+
+    @property
+    def partial_match(self) -> bool:
+        return self._partial_match

--- a/clp_ffi_py/wildcard_query.py
+++ b/clp_ffi_py/wildcard_query.py
@@ -31,9 +31,12 @@ class WildcardQuery:
         :param case_sensitive: Case sensitive indicator.
         :param partial_match: Partial match indicator.
         """
-        self._wildcard_query: str = wildcard_query
+        self._wildcard_query: str
         self._case_sensitive: bool = case_sensitive
-        self._partial_match: bool = partial_match
+        if partial_match:
+            self._wildcard_query = "*" + wildcard_query + "*"
+        else:
+            self._wildcard_query = wildcard_query
 
     def __str__(self) -> str:
         """
@@ -41,8 +44,7 @@ class WildcardQuery:
         """
         return (
             f'WildcardQuery(wildcard_query="{self._wildcard_query}",'
-            f" case_sensitive={self._case_sensitive}),"
-            f" partial_match={self._partial_match}"
+            f" case_sensitive={self._case_sensitive})"
         )
 
     def __repr__(self) -> str:
@@ -58,7 +60,3 @@ class WildcardQuery:
     @property
     def case_sensitive(self) -> bool:
         return self._case_sensitive
-
-    @property
-    def partial_match(self) -> bool:
-        return self._partial_match

--- a/src/clp_ffi_py/ir/native/Metadata.cpp
+++ b/src/clp_ffi_py/ir/native/Metadata.cpp
@@ -31,8 +31,7 @@ Metadata::Metadata(nlohmann::json const& metadata, bool is_four_byte_encoding) {
     m_is_four_byte_encoding = is_four_byte_encoding;
 
     auto const* ref_timestamp_key{
-            static_cast<char const*>(ffi::ir_stream::cProtocol::Metadata::ReferenceTimestampKey)
-    };
+            static_cast<char const*>(ffi::ir_stream::cProtocol::Metadata::ReferenceTimestampKey)};
     if (false == is_valid_json_string_data(metadata, ref_timestamp_key)) {
         throw ExceptionFFI(
                 ErrorCode_MetadataCorrupted,
@@ -49,8 +48,7 @@ Metadata::Metadata(nlohmann::json const& metadata, bool is_four_byte_encoding) {
     }
 
     auto const* timestamp_format_key{
-            static_cast<char const*>(ffi::ir_stream::cProtocol::Metadata::TimestampPatternKey)
-    };
+            static_cast<char const*>(ffi::ir_stream::cProtocol::Metadata::TimestampPatternKey)};
     if (false == is_valid_json_string_data(metadata, timestamp_format_key)) {
         throw ExceptionFFI(
                 ErrorCode_MetadataCorrupted,
@@ -62,8 +60,7 @@ Metadata::Metadata(nlohmann::json const& metadata, bool is_four_byte_encoding) {
     m_timestamp_format = metadata[timestamp_format_key];
 
     auto const* timezone_id_key{
-            static_cast<char const*>(ffi::ir_stream::cProtocol::Metadata::TimeZoneIdKey)
-    };
+            static_cast<char const*>(ffi::ir_stream::cProtocol::Metadata::TimeZoneIdKey)};
     if (false == is_valid_json_string_data(metadata, timezone_id_key)) {
         throw ExceptionFFI(
                 ErrorCode_MetadataCorrupted,

--- a/src/clp_ffi_py/ir/native/PyDecoder.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoder.cpp
@@ -55,8 +55,7 @@ PyMethodDef PyDecoder_method_table[]{
          METH_VARARGS | METH_KEYWORDS | METH_STATIC,
          static_cast<char const*>(cDecodeNextLogEventDoc)},
 
-        {nullptr, nullptr, 0, nullptr}
-};
+        {nullptr, nullptr, 0, nullptr}};
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -70,8 +69,7 @@ PyDoc_STRVAR(
 PyType_Slot PyDecoder_slots[]{
         {Py_tp_methods, static_cast<void*>(PyDecoder_method_table)},
         {Py_tp_doc, const_cast<void*>(static_cast<void const*>(cPyDecoderDoc))},
-        {0, nullptr}
-};
+        {0, nullptr}};
 // NOLINTEND(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-pro-type-const-cast)
 
 /**
@@ -82,8 +80,7 @@ PyType_Spec PyDecoder_type_spec{
         sizeof(PyDecoder),
         0,
         Py_TPFLAGS_DEFAULT,
-        static_cast<PyType_Slot*>(PyDecoder_slots)
-};
+        static_cast<PyType_Slot*>(PyDecoder_slots)};
 }  // namespace
 
 PyObjectPtr<PyTypeObject> PyDecoder::m_py_type{nullptr};

--- a/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
@@ -32,8 +32,7 @@ auto PyDecoderBuffer_init(PyDecoderBuffer* self, PyObject* args, PyObject* keywo
     static char* keyword_table[]{
             static_cast<char*>(keyword_input_stream),
             static_cast<char*>(keyword_initial_buffer_capacity),
-            nullptr
-    };
+            nullptr};
 
     // If the argument parsing fails, `self` will be deallocated. We must reset
     // all pointers to nullptr in advance, otherwise the deallocator might
@@ -55,8 +54,8 @@ auto PyDecoderBuffer_init(PyDecoderBuffer* self, PyObject* args, PyObject* keywo
         return -1;
     }
 
-    PyObjectPtr<PyObject> const readinto_method_obj{PyObject_GetAttrString(input_stream, "readinto")
-    };
+    PyObjectPtr<PyObject> const readinto_method_obj{
+            PyObject_GetAttrString(input_stream, "readinto")};
     auto* readinto_method{readinto_method_obj.get()};
     if (nullptr == readinto_method) {
         return -1;
@@ -154,8 +153,7 @@ PyMethodDef PyDecoderBuffer_method_table[]{
          METH_O,
          static_cast<char const*>(cPyDecoderBufferTestStreamingDoc)},
 
-        {nullptr}
-};
+        {nullptr}};
 
 /**
  * Declaration of Python buffer protocol.
@@ -190,8 +188,7 @@ PyType_Slot PyDecoderBuffer_slots[]{
         {Py_tp_init, reinterpret_cast<void*>(PyDecoderBuffer_init)},
         {Py_tp_methods, static_cast<void*>(PyDecoderBuffer_method_table)},
         {Py_tp_doc, const_cast<void*>(static_cast<void const*>(cPyDecoderBufferDoc))},
-        {0, nullptr}
-};
+        {0, nullptr}};
 // NOLINTEND(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-pro-type-*-cast)
 
 /**
@@ -202,8 +199,7 @@ PyType_Spec PyDecoderBuffer_type_spec{
         sizeof(PyDecoderBuffer),
         0,
         Py_TPFLAGS_DEFAULT,
-        static_cast<PyType_Slot*>(PyDecoderBuffer_slots)
-};
+        static_cast<PyType_Slot*>(PyDecoderBuffer_slots)};
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(

--- a/src/clp_ffi_py/ir/native/PyFourByteEncoder.cpp
+++ b/src/clp_ffi_py/ir/native/PyFourByteEncoder.cpp
@@ -98,8 +98,7 @@ PyMethodDef PyFourByteEncoder_method_table[]{
          METH_NOARGS | METH_STATIC,
          static_cast<char const*>(cEncodeEndOfIrDoc)},
 
-        {nullptr, nullptr, 0, nullptr}
-};
+        {nullptr, nullptr, 0, nullptr}};
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -113,8 +112,7 @@ PyDoc_STRVAR(
 PyType_Slot PyFourByteEncoder_slots[]{
         {Py_tp_methods, static_cast<void*>(PyFourByteEncoder_method_table)},
         {Py_tp_doc, const_cast<void*>(static_cast<void const*>(cPyFourByteEncoderDoc))},
-        {0, nullptr}
-};
+        {0, nullptr}};
 // NOLINTEND(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-pro-type-const-cast)
 
 /**
@@ -125,8 +123,7 @@ PyType_Spec PyFourByteEncoder_type_spec{
         sizeof(PyFourByteEncoder),
         0,
         Py_TPFLAGS_DEFAULT,
-        static_cast<PyType_Slot*>(PyFourByteEncoder_slots)
-};
+        static_cast<PyType_Slot*>(PyFourByteEncoder_slots)};
 }  // namespace
 
 PyObjectPtr<PyTypeObject> PyFourByteEncoder::m_py_type{nullptr};

--- a/src/clp_ffi_py/ir/native/PyLogEvent.cpp
+++ b/src/clp_ffi_py/ir/native/PyLogEvent.cpp
@@ -34,8 +34,7 @@ auto PyLogEvent_init(PyLogEvent* self, PyObject* args, PyObject* keywords) -> in
             static_cast<char*>(keyword_timestamp),
             static_cast<char*>(keyword_message_idx),
             static_cast<char*>(keyword_metadata),
-            nullptr
-    };
+            nullptr};
 
     // If the argument parsing fails, `self` will be deallocated. We must reset
     // all pointers to nullptr in advance, otherwise the deallocator might
@@ -122,8 +121,7 @@ auto PyLogEvent_getstate(PyLogEvent* self) -> PyObject* {
                 clp_ffi_py::py_utils_get_formatted_timestamp(
                         log_event->get_timestamp(),
                         self->has_metadata() ? self->get_py_metadata()->get_py_timezone() : Py_None
-                )
-        };
+                )};
         auto* formatted_timestamp_ptr{formatted_timestamp_object.get()};
         if (nullptr == formatted_timestamp_ptr) {
             return nullptr;
@@ -381,8 +379,7 @@ PyMethodDef PyLogEvent_method_table[]{
          METH_O,
          static_cast<char const*>(cPyLogEventSetStateDoc)},
 
-        {nullptr}
-};
+        {nullptr}};
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -413,8 +410,7 @@ PyType_Slot PyLogEvent_slots[]{
         {Py_tp_repr, reinterpret_cast<void*>(PyLogEvent_repr)},
         {Py_tp_methods, static_cast<void*>(PyLogEvent_method_table)},
         {Py_tp_doc, const_cast<void*>(static_cast<void const*>(cPyLogEventDoc))},
-        {0, nullptr}
-};
+        {0, nullptr}};
 // NOLINTEND(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-pro-type-*-cast)
 
 /**
@@ -425,8 +421,7 @@ PyType_Spec PyLogEvent_type_spec{
         sizeof(PyLogEvent),
         0,
         Py_TPFLAGS_DEFAULT,
-        static_cast<PyType_Slot*>(PyLogEvent_slots)
-};
+        static_cast<PyType_Slot*>(PyLogEvent_slots)};
 }  // namespace
 
 auto PyLogEvent::get_formatted_message(PyObject* timezone) -> PyObject* {
@@ -448,8 +443,7 @@ auto PyLogEvent::get_formatted_message(PyObject* timezone) -> PyObject* {
     }
 
     PyObjectPtr<PyObject> const formatted_timestamp_object{
-            py_utils_get_formatted_timestamp(m_log_event->get_timestamp(), timezone)
-    };
+            py_utils_get_formatted_timestamp(m_log_event->get_timestamp(), timezone)};
     auto* formatted_timestamp_ptr{formatted_timestamp_object.get()};
     if (nullptr == formatted_timestamp_ptr) {
         return nullptr;

--- a/src/clp_ffi_py/ir/native/PyMetadata.cpp
+++ b/src/clp_ffi_py/ir/native/PyMetadata.cpp
@@ -32,8 +32,7 @@ auto PyMetadata_init(PyMetadata* self, PyObject* args, PyObject* keywords) -> in
             static_cast<char*>(keyword_ref_timestamp),
             static_cast<char*>(keyword_timestamp_format),
             static_cast<char*>(keyword_timezone_id),
-            nullptr
-    };
+            nullptr};
 
     ffi::epoch_time_ms_t ref_timestamp{0};
     char const* input_timestamp_format{nullptr};
@@ -175,8 +174,7 @@ PyMethodDef PyMetadata_method_table[]{
          METH_NOARGS,
          static_cast<char const*>(cPyMetadataGetTimezoneDoc)},
 
-        {nullptr}
-};
+        {nullptr}};
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -206,8 +204,7 @@ PyType_Slot PyMetadata_slots[]{
         {Py_tp_new, reinterpret_cast<void*>(PyType_GenericNew)},
         {Py_tp_methods, static_cast<void*>(PyMetadata_method_table)},
         {Py_tp_doc, const_cast<void*>(static_cast<void const*>(cPyMetadataDoc))},
-        {0, nullptr}
-};
+        {0, nullptr}};
 // NOLINTEND(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-pro-type-*-cast)
 
 PyType_Spec PyMetadata_type_spec{
@@ -215,8 +212,7 @@ PyType_Spec PyMetadata_type_spec{
         sizeof(PyMetadata),
         0,
         Py_TPFLAGS_DEFAULT,
-        static_cast<PyType_Slot*>(PyMetadata_slots)
-};
+        static_cast<PyType_Slot*>(PyMetadata_slots)};
 }  // namespace
 
 auto PyMetadata::init(

--- a/src/clp_ffi_py/ir/native/PyQuery.cpp
+++ b/src/clp_ffi_py/ir/native/PyQuery.cpp
@@ -109,7 +109,7 @@ auto serialize_wildcard_queries(std::vector<WildcardQuery> const& wildcard_queri
     Py_ssize_t idx{0};
     for (auto const& wildcard_query : wildcard_queries) {
         PyObjectPtr<PyObject> const wildcard_py_str_ptr{
-                PyUnicode_FromString(wildcard_query.get_uncleaned_wildcard_query().c_str())
+                PyUnicode_FromString(wildcard_query.get_original_query_string().c_str())
         };
         auto* wildcard_py_str{wildcard_py_str_ptr.get()};
         if (nullptr == wildcard_py_str) {

--- a/src/clp_ffi_py/ir/native/Query.hpp
+++ b/src/clp_ffi_py/ir/native/Query.hpp
@@ -25,37 +25,18 @@ public:
      * Initializes the wildcard query by cleaning the wildcard string.
      * @param wildcard_query Wildcard query.
      * @param case_sensitive Case sensitive indicator.
-     * @param partial_match Partial match indicator.
      */
-    WildcardQuery(std::string wildcard_query, bool case_sensitive, bool partial_match)
-            : m_original_query_string(std::move(wildcard_query)),
-              m_case_sensitive(case_sensitive),
-              m_partial_match(partial_match) {
-        if (partial_match) {
-            m_wildcard_query = "*";
-            m_wildcard_query += m_original_query_string;
-            m_wildcard_query += "*";
-            m_wildcard_query = clean_up_wildcard_search_string(m_wildcard_query);
-        } else {
-            m_wildcard_query = clean_up_wildcard_search_string(m_original_query_string);
-        }
-    }
-
-    [[nodiscard]] auto get_original_query_string() const -> std::string const& {
-        return m_original_query_string;
-    }
+    WildcardQuery(std::string wildcard_query, bool case_sensitive)
+            : m_wildcard_query(std::move(wildcard_query)),
+              m_case_sensitive(case_sensitive) {}
 
     [[nodiscard]] auto get_wildcard_query() const -> std::string const& { return m_wildcard_query; }
 
     [[nodiscard]] auto is_case_sensitive() const -> bool { return m_case_sensitive; }
 
-    [[nodiscard]] auto is_partial_match() const -> bool { return m_partial_match; }
-
 private:
-    std::string m_original_query_string;
     std::string m_wildcard_query;
     bool m_case_sensitive;
-    bool m_partial_match;
 };
 
 /**
@@ -79,11 +60,9 @@ class Query {
 public:
     static constexpr ffi::epoch_time_ms_t const cTimestampMin{0};
     static constexpr ffi::epoch_time_ms_t const cTimestampMax{
-            std::numeric_limits<ffi::epoch_time_ms_t>::max()
-    };
+            std::numeric_limits<ffi::epoch_time_ms_t>::max()};
     static constexpr ffi::epoch_time_ms_t const cDefaultSearchTimeTerminationMargin{
-            static_cast<ffi::epoch_time_ms_t>(60 * 1000)
-    };
+            static_cast<ffi::epoch_time_ms_t>(60 * 1000)};
 
     /**
      * Constructs an empty query object that will match all logs. The wildcard
@@ -114,8 +93,7 @@ public:
               m_search_termination_ts{
                       (cTimestampMax - search_time_termination_margin > search_time_upper_bound)
                               ? search_time_upper_bound + search_time_termination_margin
-                              : cTimestampMax
-              } {
+                              : cTimestampMax} {
         throw_if_ts_range_invalid();
     }
 
@@ -138,8 +116,7 @@ public:
               m_search_termination_ts{
                       (cTimestampMax - search_time_termination_margin > search_time_upper_bound)
                               ? search_time_upper_bound + search_time_termination_margin
-                              : cTimestampMax
-              },
+                              : cTimestampMax},
               m_wildcard_queries{std::move(wildcard_queries)} {
         throw_if_ts_range_invalid();
     }

--- a/src/clp_ffi_py/ir/native/Query.hpp
+++ b/src/clp_ffi_py/ir/native/Query.hpp
@@ -28,21 +28,21 @@ public:
      * @param partial_match Partial match indicator.
      */
     WildcardQuery(std::string wildcard_query, bool case_sensitive, bool partial_match)
-            : m_uncleaned_wildcard_query(std::move(wildcard_query)),
+            : m_original_query_string(std::move(wildcard_query)),
               m_case_sensitive(case_sensitive),
               m_partial_match(partial_match) {
         if (partial_match) {
             m_wildcard_query = "*";
-            m_wildcard_query += m_uncleaned_wildcard_query;
+            m_wildcard_query += m_original_query_string;
             m_wildcard_query += "*";
             m_wildcard_query = clean_up_wildcard_search_string(m_wildcard_query);
         } else {
-            m_wildcard_query = clean_up_wildcard_search_string(m_uncleaned_wildcard_query);
+            m_wildcard_query = clean_up_wildcard_search_string(m_original_query_string);
         }
     }
 
-    [[nodiscard]] auto get_uncleaned_wildcard_query() const -> std::string const& {
-        return m_uncleaned_wildcard_query;
+    [[nodiscard]] auto get_original_query_string() const -> std::string const& {
+        return m_original_query_string;
     }
 
     [[nodiscard]] auto get_wildcard_query() const -> std::string const& { return m_wildcard_query; }
@@ -52,7 +52,7 @@ public:
     [[nodiscard]] auto is_partial_match() const -> bool { return m_partial_match; }
 
 private:
-    std::string m_uncleaned_wildcard_query;
+    std::string m_original_query_string;
     std::string m_wildcard_query;
     bool m_case_sensitive;
     bool m_partial_match;

--- a/src/clp_ffi_py/ir/native/decoding_methods.cpp
+++ b/src/clp_ffi_py/ir/native/decoding_methods.cpp
@@ -171,8 +171,7 @@ auto decode_preamble(PyObject* Py_UNUSED(self), PyObject* py_decoder_buffer) -> 
 
     auto const unconsumed_bytes = decoder_buffer->get_unconsumed_bytes();
     auto const metadata_buffer{
-            unconsumed_bytes.subspan(metadata_pos, static_cast<size_t>(metadata_size))
-    };
+            unconsumed_bytes.subspan(metadata_pos, static_cast<size_t>(metadata_size))};
     decoder_buffer->commit_read_buffer_consumption(static_cast<Py_ssize_t>(ir_buffer_cursor_pos));
     PyMetadata* metadata{nullptr};
     try {
@@ -201,8 +200,7 @@ auto decode_next_log_event(PyObject* Py_UNUSED(self), PyObject* args, PyObject* 
             static_cast<char*>(keyword_decoder_buffer),
             static_cast<char*>(keyword_query),
             static_cast<char*>(keyword_allow_incomplete_stream),
-            nullptr
-    };
+            nullptr};
 
     PyDecoderBuffer* decoder_buffer{nullptr};
     PyObject* query{Py_None};

--- a/src/clp_ffi_py/ir/native/encoding_methods.cpp
+++ b/src/clp_ffi_py/ir/native/encoding_methods.cpp
@@ -33,8 +33,7 @@ auto encode_four_byte_preamble(PyObject* Py_UNUSED(self), PyObject* args) -> PyO
 
     std::string_view const timestamp_format{
             input_timestamp_format,
-            static_cast<size_t>(input_timestamp_format_size)
-    };
+            static_cast<size_t>(input_timestamp_format_size)};
     std::string_view const timezone{input_timezone, static_cast<size_t>(input_timezone_size)};
     std::vector<int8_t> ir_buf;
 

--- a/tests/test_ir/test_query.py
+++ b/tests/test_ir/test_query.py
@@ -20,23 +20,25 @@ class TestCaseWildcardQuery(TestCLPBase):
         Test the initialization of WildcardQuery object.
         """
         wildcard_string: str
+        processed_wildcard_string: str
         wildcard_query: WildcardQuery
 
         wildcard_string = "Are you the lord of *Pleiades*?"
+        processed_wildcard_string = "*" + wildcard_string + "*"
         wildcard_query = WildcardQuery(wildcard_string)
-        self._check_wildcard_query(wildcard_query, wildcard_string, False, True)
+        self._check_wildcard_query(wildcard_query, processed_wildcard_string, False)
 
         wildcard_query = WildcardQuery(wildcard_string, True)
-        self._check_wildcard_query(wildcard_query, wildcard_string, True, True)
+        self._check_wildcard_query(wildcard_query, processed_wildcard_string, True)
 
         wildcard_query = WildcardQuery(wildcard_string, case_sensitive=True)
-        self._check_wildcard_query(wildcard_query, wildcard_string, True, True)
+        self._check_wildcard_query(wildcard_query, processed_wildcard_string, True)
 
         wildcard_query = WildcardQuery(case_sensitive=True, wildcard_query=wildcard_string)
-        self._check_wildcard_query(wildcard_query, wildcard_string, True, True)
+        self._check_wildcard_query(wildcard_query, processed_wildcard_string, True)
 
         wildcard_query = WildcardQuery(partial_match=False, wildcard_query=wildcard_string)
-        self._check_wildcard_query(wildcard_query, wildcard_string, False, False)
+        self._check_wildcard_query(wildcard_query, wildcard_string, False)
 
 
 class TestCaseQuery(TestCLPBase):
@@ -175,9 +177,9 @@ class TestCaseQuery(TestCLPBase):
         )
 
         wildcard_queries = [
-            WildcardQuery("who is \*** pleiades??\\"),
-            WildcardQuery("a\?m********I?\\", case_sensitive=True),
-            WildcardQuery("\g\%\*\??***", partial_match=False),
+            WildcardQuery("who is \** pleiades??\\"),
+            WildcardQuery("a\?m*I?\\", case_sensitive=True),
+            WildcardQuery("g%\*\??*", partial_match=False),
         ]
         query = Query(wildcard_queries=wildcard_queries)
         self._check_query(

--- a/tests/test_ir/test_query_builder.py
+++ b/tests/test_ir/test_query_builder.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from test_ir.test_utils import TestCLPBase
 
@@ -112,17 +112,15 @@ class TestCaseQueryBuilder(TestCLPBase):
             search_time_termination_margin,
         )
 
-        wildcard_queries = [
-            WildcardQuery("aaa*aaa"),
-            WildcardQuery("bbb*bbb", True),
-            WildcardQuery("full match", True, False),
+        wildcard_queries = []
+        wildcard_query_tuples: List[Tuple[str, bool, bool]] = [
+            ("aaa*aaa", False, True),
+            ("bbb*bbb", True, True),
+            ("full match", True, False),
         ]
-        for wildcard_query in wildcard_queries:
-            query_builder.add_wildcard_query(
-                wildcard_query.wildcard_query,
-                wildcard_query.case_sensitive,
-                wildcard_query.partial_match,
-            )
+        for wildcard_str, case_sensitive, partial_match in wildcard_query_tuples:
+            query_builder.add_wildcard_query(wildcard_str, case_sensitive, partial_match)
+            wildcard_queries.append(WildcardQuery(wildcard_str, case_sensitive, partial_match))
         extra_wildcard_queries = [WildcardQuery("ccc?ccc", True), WildcardQuery("ddd?ddd")]
         query_builder.add_wildcard_queries(extra_wildcard_queries)
         wildcard_queries.extend(extra_wildcard_queries)

--- a/tests/test_ir/test_query_builder.py
+++ b/tests/test_ir/test_query_builder.py
@@ -112,10 +112,16 @@ class TestCaseQueryBuilder(TestCLPBase):
             search_time_termination_margin,
         )
 
-        wildcard_queries = [WildcardQuery("aaa*aaa"), WildcardQuery("bbb*bbb", True)]
+        wildcard_queries = [
+            WildcardQuery("aaa*aaa"),
+            WildcardQuery("bbb*bbb", True),
+            WildcardQuery("full match", True, False),
+        ]
         for wildcard_query in wildcard_queries:
             query_builder.add_wildcard_query(
-                wildcard_query.wildcard_query, wildcard_query.case_sensitive
+                wildcard_query.wildcard_query,
+                wildcard_query.case_sensitive,
+                wildcard_query.partial_match,
             )
         extra_wildcard_queries = [WildcardQuery("ccc?ccc", True), WildcardQuery("ddd?ddd")]
         query_builder.add_wildcard_queries(extra_wildcard_queries)

--- a/tests/test_ir/test_utils.py
+++ b/tests/test_ir/test_utils.py
@@ -146,7 +146,6 @@ class TestCLPBase(unittest.TestCase):
         wildcard_query: WildcardQuery,
         ref_wildcard_string: str,
         ref_is_case_sensitive: bool,
-        ref_is_partial_match: bool,
     ) -> None:
         """
         Given a WildcardQuery object, check if the stored data matches the input
@@ -155,11 +154,9 @@ class TestCLPBase(unittest.TestCase):
         :param wildcard_query: Input WildcardQuery object.
         :param ref_wildcard_string: Reference wildcard string.
         :param ref_is_case_sensitive: Reference case-sensitive indicator.
-        :param ref_is_partial_match: Reference partial-match indicator.
         """
         wildcard_string: str = wildcard_query.wildcard_query
         is_case_sensitive: bool = wildcard_query.case_sensitive
-        is_partial_match: bool = wildcard_query.partial_match
         self.assertEqual(
             wildcard_string,
             ref_wildcard_string,
@@ -169,11 +166,6 @@ class TestCLPBase(unittest.TestCase):
             is_case_sensitive,
             ref_is_case_sensitive,
             f"Expected case-sensitive indicator: {ref_is_case_sensitive}",
-        )
-        self.assertEqual(
-            is_partial_match,
-            ref_is_partial_match,
-            f"Expected partial-match indicator: {ref_is_partial_match}",
         )
 
     def _check_query(
@@ -235,7 +227,6 @@ class TestCLPBase(unittest.TestCase):
                 wildcard_queries[i],
                 ref_wildcard_queries[i].wildcard_query,
                 ref_wildcard_queries[i].case_sensitive,
-                ref_wildcard_queries[i].partial_match,
             )
 
 

--- a/tests/test_ir/test_utils.py
+++ b/tests/test_ir/test_utils.py
@@ -142,7 +142,11 @@ class TestCLPBase(unittest.TestCase):
         )
 
     def _check_wildcard_query(
-        self, wildcard_query: WildcardQuery, ref_wildcard_string: str, ref_is_case_sensitive: bool
+        self,
+        wildcard_query: WildcardQuery,
+        ref_wildcard_string: str,
+        ref_is_case_sensitive: bool,
+        ref_is_partial_match: bool,
     ) -> None:
         """
         Given a WildcardQuery object, check if the stored data matches the input
@@ -151,9 +155,11 @@ class TestCLPBase(unittest.TestCase):
         :param wildcard_query: Input WildcardQuery object.
         :param ref_wildcard_string: Reference wildcard string.
         :param ref_is_case_sensitive: Reference case-sensitive indicator.
+        :param ref_is_partial_match: Reference partial-match indicator.
         """
         wildcard_string: str = wildcard_query.wildcard_query
         is_case_sensitive: bool = wildcard_query.case_sensitive
+        is_partial_match: bool = wildcard_query.partial_match
         self.assertEqual(
             wildcard_string,
             ref_wildcard_string,
@@ -163,6 +169,11 @@ class TestCLPBase(unittest.TestCase):
             is_case_sensitive,
             ref_is_case_sensitive,
             f"Expected case-sensitive indicator: {ref_is_case_sensitive}",
+        )
+        self.assertEqual(
+            is_partial_match,
+            ref_is_partial_match,
+            f"Expected partial-match indicator: {ref_is_partial_match}",
         )
 
     def _check_query(
@@ -224,6 +235,7 @@ class TestCLPBase(unittest.TestCase):
                 wildcard_queries[i],
                 ref_wildcard_queries[i].wildcard_query,
                 ref_wildcard_queries[i].case_sensitive,
+                ref_wildcard_queries[i].partial_match,
             )
 
 


### PR DESCRIPTION
# Description
In most cases, users want to search for any result containing the given wildcard search string. This is implemented as "partial matching", which is the default search query in `clg`. This PR implements partial matching as the default option when building the wildcard query.
In terms of the low level implementation details, a partial match wildcard query `"${WILDCARD_STRING}"` is equivalent to the full match wildcard query `*${WILDCARD_STRING}*`.

# Validation performed
1. Update the unit tests to cover the partial match.
2. All linters passed.

