### PR TITLE
Fix: implement trivial destructors for static PyObject unique pointers to avoid invalid memory access on exit

### DIFF
--- a/src/clp_ffi_py/PyObjectUtils.hpp
+++ b/src/clp_ffi_py/PyObjectUtils.hpp
@@ -38,10 +38,14 @@ template <typename PyObjectType>
 using PyObjectPtr = std::unique_ptr<PyObjectType, PyObjectDeleter<PyObjectType>>;
 
 /**
- * A type of smart pointer that holds a static Python object raw pointer. For
- * static/global variables, the destructor will be executed after the Python
- * interpreter exits. Therefore, the destructor is set to empty to avoid unsafe
- * memory operations.
+ * A smart pointer to be used for raw Python object pointers that have static
+ * storage duration. It holds a reference of the underlying Python object.
+ * Compared to PyObjectPtr, when destructed, this smart pointer does not
+ * decrease the reference count of the contained Python object. Since this
+ * pointer has static storage duration, it's possible that the Python
+ * interpreter exits before this pointer's destructor is called; attempting to
+ * decrement the reference count (maintained by the interpreter) in this
+ * situation would lead to undefined behaviour.
  * @tparam PyObjectType
  */
 template <typename PyObjectType>

--- a/src/clp_ffi_py/PyObjectUtils.hpp
+++ b/src/clp_ffi_py/PyObjectUtils.hpp
@@ -19,11 +19,32 @@ public:
 };
 
 /**
+ * An empty deleter that has an empty implementation to ensure object trivial
+ * destruction.
+ * @tparam PyObjectType
+ */
+template <typename PyObjectType>
+class PyObjectTrivialDeleter {
+public:
+    void operator()(PyObjectType* ptr) {}
+};
+
+/**
  * A type of smart pointer that maintains a reference to a Python object for the
  * duration of its lifetime.
  * @tparam PyObjectType
  */
 template <typename PyObjectType>
 using PyObjectPtr = std::unique_ptr<PyObjectType, PyObjectDeleter<PyObjectType>>;
+
+/**
+ * A type of smart pointer that holds a static Python object raw pointer. For
+ * static/global variables, the destructor will be executed after the Python
+ * interpreter exits. Therefore, the destructor is set to empty to avoid unsafe
+ * memory operations.
+ * @tparam PyObjectType
+ */
+template <typename PyObjectType>
+using PyObjectStaticPtr = std::unique_ptr<PyObjectType, PyObjectTrivialDeleter<PyObjectType>>;
 }  // namespace clp_ffi_py
 #endif  // CLP_FFI_PY_PY_OBJECT_PTR_HPP

--- a/src/clp_ffi_py/Py_utils.cpp
+++ b/src/clp_ffi_py/Py_utils.cpp
@@ -7,10 +7,10 @@
 namespace clp_ffi_py {
 namespace {
 constexpr char const* const cPyFuncNameGetFormattedTimestamp{"get_formatted_timestamp"};
-PyObjectPtr<PyObject> Py_func_get_formatted_timestamp;
+PyObjectStaticPtr<PyObject> Py_func_get_formatted_timestamp;
 
 constexpr char const* const cPyFuncNameGetTimezoneFromTimezoneId{"get_timezone_from_timezone_id"};
-PyObjectPtr<PyObject> Py_func_get_timezone_from_timezone_id;
+PyObjectStaticPtr<PyObject> Py_func_get_timezone_from_timezone_id;
 
 /**
  * Wrapper of PyObject_CallObject.

--- a/src/clp_ffi_py/Py_utils.cpp
+++ b/src/clp_ffi_py/Py_utils.cpp
@@ -7,10 +7,10 @@
 namespace clp_ffi_py {
 namespace {
 constexpr char const* const cPyFuncNameGetFormattedTimestamp{"get_formatted_timestamp"};
-PyObjectStaticPtr<PyObject> Py_func_get_formatted_timestamp;
+PyObjectStaticPtr<PyObject> Py_func_get_formatted_timestamp{nullptr};
 
 constexpr char const* const cPyFuncNameGetTimezoneFromTimezoneId{"get_timezone_from_timezone_id"};
-PyObjectStaticPtr<PyObject> Py_func_get_timezone_from_timezone_id;
+PyObjectStaticPtr<PyObject> Py_func_get_timezone_from_timezone_id{nullptr};
 
 /**
  * Wrapper of PyObject_CallObject.

--- a/src/clp_ffi_py/ir/native/PyDecoder.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoder.cpp
@@ -86,7 +86,7 @@ PyType_Spec PyDecoder_type_spec{
 };
 }  // namespace
 
-PyObjectPtr<PyTypeObject> PyDecoder::m_py_type{nullptr};
+PyObjectStaticPtr<PyTypeObject> PyDecoder::m_py_type{nullptr};
 
 auto PyDecoder::module_level_init(PyObject* py_module) -> bool {
     static_assert(std::is_trivially_destructible<PyDecoder>());

--- a/src/clp_ffi_py/ir/native/PyDecoder.hpp
+++ b/src/clp_ffi_py/ir/native/PyDecoder.hpp
@@ -25,7 +25,7 @@ public:
 private:
     PyObject_HEAD;
 
-    static PyObjectPtr<PyTypeObject> m_py_type;
+    static PyObjectStaticPtr<PyTypeObject> m_py_type;
 };
 }  // namespace clp_ffi_py::ir::native
 

--- a/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
@@ -350,8 +350,8 @@ auto PyDecoderBuffer::test_streaming(uint32_t seed) -> PyObject* {
     );
 }
 
-PyObjectPtr<PyTypeObject> PyDecoderBuffer::m_py_type{nullptr};
-PyObjectPtr<PyObject> PyDecoderBuffer::m_py_incomplete_stream_error{nullptr};
+PyObjectStaticPtr<PyTypeObject> PyDecoderBuffer::m_py_type{nullptr};
+PyObjectStaticPtr<PyObject> PyDecoderBuffer::m_py_incomplete_stream_error{nullptr};
 
 auto PyDecoderBuffer::get_py_type() -> PyTypeObject* {
     return m_py_type.get();

--- a/src/clp_ffi_py/ir/native/PyDecoderBuffer.hpp
+++ b/src/clp_ffi_py/ir/native/PyDecoderBuffer.hpp
@@ -221,8 +221,8 @@ private:
     size_t m_num_decoded_message;
     bool m_py_buffer_protocol_enabled;
 
-    static PyObjectPtr<PyTypeObject> m_py_type;
-    static PyObjectPtr<PyObject> m_py_incomplete_stream_error;
+    static PyObjectStaticPtr<PyTypeObject> m_py_type;
+    static PyObjectStaticPtr<PyObject> m_py_incomplete_stream_error;
 };
 }  // namespace clp_ffi_py::ir::native
 #endif

--- a/src/clp_ffi_py/ir/native/PyFourByteEncoder.cpp
+++ b/src/clp_ffi_py/ir/native/PyFourByteEncoder.cpp
@@ -129,7 +129,7 @@ PyType_Spec PyFourByteEncoder_type_spec{
 };
 }  // namespace
 
-PyObjectPtr<PyTypeObject> PyFourByteEncoder::m_py_type{nullptr};
+PyObjectStaticPtr<PyTypeObject> PyFourByteEncoder::m_py_type{nullptr};
 
 auto PyFourByteEncoder::module_level_init(PyObject* py_module) -> bool {
     static_assert(std::is_trivially_destructible<PyFourByteEncoder>());

--- a/src/clp_ffi_py/ir/native/PyFourByteEncoder.hpp
+++ b/src/clp_ffi_py/ir/native/PyFourByteEncoder.hpp
@@ -26,7 +26,7 @@ public:
 private:
     PyObject_HEAD;
 
-    static PyObjectPtr<PyTypeObject> m_py_type;
+    static PyObjectStaticPtr<PyTypeObject> m_py_type;
 };
 }  // namespace clp_ffi_py::ir::native
 #endif

--- a/src/clp_ffi_py/ir/native/PyLogEvent.cpp
+++ b/src/clp_ffi_py/ir/native/PyLogEvent.cpp
@@ -486,7 +486,7 @@ auto PyLogEvent::init(
     return true;
 }
 
-PyObjectPtr<PyTypeObject> PyLogEvent::m_py_type{nullptr};
+PyObjectStaticPtr<PyTypeObject> PyLogEvent::m_py_type{nullptr};
 
 auto PyLogEvent::get_py_type() -> PyTypeObject* {
     return m_py_type.get();

--- a/src/clp_ffi_py/ir/native/PyLogEvent.hpp
+++ b/src/clp_ffi_py/ir/native/PyLogEvent.hpp
@@ -144,7 +144,7 @@ private:
     LogEvent* m_log_event;
     PyMetadata* m_py_metadata;
 
-    static PyObjectPtr<PyTypeObject> m_py_type;
+    static PyObjectStaticPtr<PyTypeObject> m_py_type;
 };
 }  // namespace clp_ffi_py::ir::native
 #endif  // CLP_FFI_PY_PY_LOG_EVENT_HPP

--- a/src/clp_ffi_py/ir/native/PyMetadata.cpp
+++ b/src/clp_ffi_py/ir/native/PyMetadata.cpp
@@ -263,7 +263,7 @@ auto PyMetadata::init_py_timezone() -> bool {
     return true;
 }
 
-PyObjectPtr<PyTypeObject> PyMetadata::m_py_type{nullptr};
+PyObjectStaticPtr<PyTypeObject> PyMetadata::m_py_type{nullptr};
 
 auto PyMetadata::get_py_type() -> PyTypeObject* {
     return m_py_type.get();

--- a/src/clp_ffi_py/ir/native/PyMetadata.hpp
+++ b/src/clp_ffi_py/ir/native/PyMetadata.hpp
@@ -117,7 +117,7 @@ private:
     Metadata* m_metadata;
     PyObject* m_py_timezone;
 
-    static PyObjectPtr<PyTypeObject> m_py_type;
+    static PyObjectStaticPtr<PyTypeObject> m_py_type;
 };
 }  // namespace clp_ffi_py::ir::native
 #endif  // CLP_FFI_PY_PY_METADATA_HPP

--- a/src/clp_ffi_py/ir/native/PyQuery.cpp
+++ b/src/clp_ffi_py/ir/native/PyQuery.cpp
@@ -636,8 +636,8 @@ auto PyQuery::init(
     return true;
 }
 
-PyObjectPtr<PyTypeObject> PyQuery::m_py_type{nullptr};
-PyObjectPtr<PyObject> PyQuery::m_py_wildcard_query_type{nullptr};
+PyObjectStaticPtr<PyTypeObject> PyQuery::m_py_type{nullptr};
+PyObjectStaticPtr<PyObject> PyQuery::m_py_wildcard_query_type{nullptr};
 
 auto PyQuery::get_py_type() -> PyTypeObject* {
     return m_py_type.get();

--- a/src/clp_ffi_py/ir/native/PyQuery.hpp
+++ b/src/clp_ffi_py/ir/native/PyQuery.hpp
@@ -80,8 +80,8 @@ private:
     PyObject_HEAD;
     Query* m_query;
 
-    static PyObjectPtr<PyTypeObject> m_py_type;
-    static PyObjectPtr<PyObject> m_py_wildcard_query_type;
+    static PyObjectStaticPtr<PyTypeObject> m_py_type;
+    static PyObjectStaticPtr<PyObject> m_py_wildcard_query_type;
 };
 }  // namespace clp_ffi_py::ir::native
 #endif


### PR DESCRIPTION
# Description
The static destructors of the global/static PyObject unique pointers (such as Py types and exceptions) will attempt to decrease the reference count when the process exits. However, its behavior is undefined due to the following reasons, which was first exposed in Python 3.10.12 on Linux with a segfault on exit:

1. the Python interpreter can exit before the global/static destructors execute. Accessing the reference count is illegal if the interpreter is already shut down. There is no way to guarantee the ordering of the execution for the interpreter cleanup and the global/static destructors.
2. C++ RAII guarantees that some code will execute when the scope exits, but it doesn't guarantee that all of the code finishes executing; the process may exit before the RAII destructor is complete.

This PR fixes the problem by making all the global/static Pyobject pointers trivially destructible. This means it will not attempt to release any resources when reset or destruction happens, which can lead to potential memory leaks. However, according to the current use case, this is acceptable since the only expected execution of the trivial destructor is on process exit. 

We keep using smart ptr for two purposes: 
1. protect the underlying raw pointers from being exposed and accidentally modified.
2. indicate the underlying object will never be freed by C++ static destructor.

