### PR TITLE
Fix static type checking in Python3.6 with missing import on `__future__.annotations`; Fix the unittests undefined behaviour triggered on macOS.

### DIFF
--- a/clp_ffi_py/ir/query_builder.py
+++ b/clp_ffi_py/ir/query_builder.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from copy import deepcopy
 from typing import List, Optional
 
@@ -51,7 +49,7 @@ class QueryBuilder:
         """
         return deepcopy(self._wildcard_queries)
 
-    def set_search_time_lower_bound(self, ts: int) -> QueryBuilder:
+    def set_search_time_lower_bound(self, ts: int) -> "QueryBuilder":
         """
         :param ts: Start of the search time range (inclusive) as a UNIX epoch
             timestamp in milliseconds.
@@ -60,7 +58,7 @@ class QueryBuilder:
         self._search_time_lower_bound = ts
         return self
 
-    def set_search_time_upper_bound(self, ts: int) -> QueryBuilder:
+    def set_search_time_upper_bound(self, ts: int) -> "QueryBuilder":
         """
         :param ts: End of the search time range (inclusive) as a UNIX epoch
             timestamp in milliseconds.
@@ -69,7 +67,7 @@ class QueryBuilder:
         self._search_time_upper_bound = ts
         return self
 
-    def set_search_time_termination_margin(self, ts: int) -> QueryBuilder:
+    def set_search_time_termination_margin(self, ts: int) -> "QueryBuilder":
         """
         :param ts: The search time termination margin as a UNIX epoch timestamp
             in milliseconds.
@@ -78,7 +76,9 @@ class QueryBuilder:
         self._search_time_termination_margin = ts
         return self
 
-    def add_wildcard_query(self, wildcard_query: str, case_sensitive: bool = False) -> QueryBuilder:
+    def add_wildcard_query(
+        self, wildcard_query: str, case_sensitive: bool = False
+    ) -> "QueryBuilder":
         """
         Constructs and adds a :class:`~clp_ffi_py.wildcard_query.WildcardQuery`
         to the wildcard query list.
@@ -90,7 +90,7 @@ class QueryBuilder:
         self._wildcard_queries.append(WildcardQuery(wildcard_query, case_sensitive))
         return self
 
-    def add_wildcard_queries(self, wildcard_queries: List[WildcardQuery]) -> QueryBuilder:
+    def add_wildcard_queries(self, wildcard_queries: List[WildcardQuery]) -> "QueryBuilder":
         """
         Adds a list of wildcard queries to the wildcard query list.
 
@@ -100,7 +100,7 @@ class QueryBuilder:
         self._wildcard_queries.extend(wildcard_queries)
         return self
 
-    def reset_search_time_lower_bound(self) -> QueryBuilder:
+    def reset_search_time_lower_bound(self) -> "QueryBuilder":
         """
         Resets the search time lower bound to the default value.
 
@@ -109,7 +109,7 @@ class QueryBuilder:
         self._search_time_lower_bound = Query.default_search_time_lower_bound()
         return self
 
-    def reset_search_time_upper_bound(self) -> QueryBuilder:
+    def reset_search_time_upper_bound(self) -> "QueryBuilder":
         """
         Resets the search time upper bound to the default value.
 
@@ -118,7 +118,7 @@ class QueryBuilder:
         self._search_time_upper_bound = Query.default_search_time_upper_bound()
         return self
 
-    def reset_search_time_termination_margin(self) -> QueryBuilder:
+    def reset_search_time_termination_margin(self) -> "QueryBuilder":
         """
         Resets the search time termination margin to the default value.
 
@@ -127,7 +127,7 @@ class QueryBuilder:
         self._search_time_termination_margin = Query.default_search_time_termination_margin()
         return self
 
-    def reset_wildcard_queries(self) -> QueryBuilder:
+    def reset_wildcard_queries(self) -> "QueryBuilder":
         """
         Clears the wildcard query list.
 
@@ -136,7 +136,7 @@ class QueryBuilder:
         self._wildcard_queries.clear()
         return self
 
-    def reset(self) -> QueryBuilder:
+    def reset(self) -> "QueryBuilder":
         """
         Resets all settings to their defaults.
 

--- a/clp_ffi_py/ir/readers.py
+++ b/clp_ffi_py/ir/readers.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from pathlib import Path
 from sys import stderr
 from types import TracebackType
@@ -105,12 +103,12 @@ class ClpIrStreamReader(Iterator[LogEvent]):
     def close(self) -> None:
         self.__istream.close()
 
-    def __iter__(self) -> ClpIrStreamReader:
+    def __iter__(self) -> "ClpIrStreamReader":
         if False is self.has_metadata():
             self.read_preamble()
         return self
 
-    def __enter__(self) -> ClpIrStreamReader:
+    def __enter__(self) -> "ClpIrStreamReader":
         if False is self.has_metadata():
             self.read_preamble()
         return self

--- a/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
@@ -327,7 +327,7 @@ auto PyDecoderBuffer::test_streaming(uint32_t seed) -> PyObject* {
     std::vector<uint8_t> read_bytes;
     bool reach_istream_end{false};
     while (false == reach_istream_end) {
-        std::uniform_int_distribution<Py_ssize_t> distribution(1, m_buffer_size);
+        std::uniform_int_distribution<Py_ssize_t> distribution(1, m_read_buffer.size());
         auto num_bytes_to_read{distribution(rand_generator)};
         if (get_num_unconsumed_bytes() < num_bytes_to_read) {
             Py_ssize_t num_bytes_read_from_istream{0};


### PR DESCRIPTION
# Description
This PR fixes two problems caught from development and deployment:
1. `__future__.annotations` allows type-checking when the class method returns itself. However, this feature was first introduced in Python3.7; it causes a missing import when executing under Python3.6. This PR fixes this problem by dropping `__future__.annotations` and using the string literal of the class name instead to refer to the type.
2. When executing the unit tests on macOS, the Python interpreter is crashed by an undefined behavior written in the DecoderBuffer testing code. When the buffer is not initialized, the `m_buffer_size` equals 0, creating a distribution [1, 0] and thus generating an unexpected negative number, further triggering the out-of-bound memory access.

