### PR TITLE
Replace memcpy with std::copy to avoid undefined behaviour when buffers overlap.

### DIFF
--- a/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
@@ -245,7 +245,7 @@ auto PyDecoderBuffer::populate_read_buffer(Py_ssize_t& num_bytes_read) -> bool {
         m_read_buffer_mem_owner = new_buf;
         m_read_buffer = new_read_buffer;
     } else if (0 < num_unconsumed_bytes) {
-        memcpy(m_read_buffer.data(), unconsumed_bytes.data(), num_unconsumed_bytes);
+        memmove(m_read_buffer.data(), unconsumed_bytes.data(), num_unconsumed_bytes);
     }
     m_num_current_bytes_consumed = 0;
     m_buffer_size = num_unconsumed_bytes;


### PR DESCRIPTION
# Description
In the current implementation, the code uses `memcpy` to copy the unconsumed bytes from the end of the buffer to the beginning. In most cases, this is safe because the previous `if` statement handles the cases where more than half of bytes in the current buffer are unconsumed. However, the corner case happens when the number of unconsumed bytes is larger than half of the actual buffer size (not the capacity). If this happens, the behavior of the code depends on the underlying `memcpy` implementation. This PR solves this UB by replacing `memcpy` with `std::copy`, so it will be safe even if the src and dst buffers overlap.
Notice that there will be a performance drop with the changes in this PR since `std::copy` cannot optimize `gsl::span`. However, this problem will be fix after switching to C++20 with `std::span`.