### PR TITLE
Upgrade the C++ standard to C++20; Replace gsl::span with std::span.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -76,8 +76,6 @@ IncludeCategories:
   # Third-party headers. Update when adding new third-party library
   - Regex: '^<(clp)'
     Priority: 3
-  - Regex: '<(gsl)'
-    Priority: 3
   - Regex: '<(json)'
     Priority: 3
   # C headers

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "src/clp"]
 	path = src/clp
 	url = https://github.com/y-scope/clp.git
-[submodule "src/GSL"]
-	path = src/GSL
-	url = https://github.com/microsoft/GSL.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,5 +8,4 @@ recursive-include clp_ffi_py *.pyi
 recursive-include clp_ffi_py py.typed
 include setup.cfg
 include src/clp/components/core/submodules/json/single_include/nlohmann/json.hpp
-include src/GSL/include/gsl/*
 recursive-include tests *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,13 @@ color = true
 preview = true
 
 [tool.cibuildwheel]
+# Use `musllinux_1_2` to support C++20 compilation
 musllinux-aarch64-image = "musllinux_1_2"
 musllinux-i686-image = "musllinux_1_2"
 musllinux-ppc64le-image = "musllinux_1_2"
 musllinux-s390x-image = "musllinux_1_2"
 musllinux-x86_64-image = "musllinux_1_2"
+
 skip = "pp*"
 
 test-command = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ color = true
 preview = true
 
 [tool.cibuildwheel]
+musllinux-aarch64-image = "musllinux_1_2"
+musllinux-i686-image = "musllinux_1_2"
+musllinux-ppc64le-image = "musllinux_1_2"
+musllinux-s390x-image = "musllinux_1_2"
+musllinux-x86_64-image = "musllinux_1_2"
 skip = "pp*"
 
 test-command = [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ ir_native: Extension = Extension(
     language="c++",
     include_dirs=[
         "src",
-        "src/GSL/include",
         "src/clp/components/core/submodules",
     ],
     sources=[

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ ir_native: Extension = Extension(
         "src/clp_ffi_py/utils.cpp",
     ],
     extra_compile_args=[
-        "-std=c++17",
+        "-std=c++20",
         "-O3",
     ],
     define_macros=[("SOURCE_PATH_SIZE", str(len(os.path.abspath("./src/clp/components/core"))))],

--- a/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <random>
+#include <span>
 
 #include <clp_ffi_py/error_messages.hpp>
 #include <clp_ffi_py/ir/native/error_messages.hpp>
@@ -220,7 +221,7 @@ auto PyDecoderBuffer::init(PyObject* input_stream, Py_ssize_t buf_capacity) -> b
         PyErr_NoMemory();
         return false;
     }
-    m_read_buffer = gsl::span<int8_t>(m_read_buffer_mem_owner, buf_capacity);
+    m_read_buffer = std::span<int8_t>(m_read_buffer_mem_owner, buf_capacity);
     m_input_ir_stream = input_stream;
     Py_INCREF(m_input_ir_stream);
     return true;
@@ -241,7 +242,7 @@ auto PyDecoderBuffer::populate_read_buffer(Py_ssize_t& num_bytes_read) -> bool {
             PyErr_NoMemory();
             return false;
         }
-        auto new_read_buffer{gsl::span<int8_t>(new_buf, new_capacity)};
+        auto new_read_buffer{std::span<int8_t>(new_buf, new_capacity)};
         std::copy(
                 unconsumed_bytes_in_curr_read_buffer.begin(),
                 unconsumed_bytes_in_curr_read_buffer.end(),

--- a/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
@@ -242,7 +242,7 @@ auto PyDecoderBuffer::populate_read_buffer(Py_ssize_t& num_bytes_read) -> bool {
             PyErr_NoMemory();
             return false;
         }
-        auto new_read_buffer{std::span<int8_t>(new_buf, new_capacity)};
+        std::span<int8_t> new_read_buffer{new_buf, static_cast<size_t>(new_capacity)};
         std::copy(
                 unconsumed_bytes_in_curr_read_buffer.begin(),
                 unconsumed_bytes_in_curr_read_buffer.end(),

--- a/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoderBuffer.cpp
@@ -221,7 +221,7 @@ auto PyDecoderBuffer::init(PyObject* input_stream, Py_ssize_t buf_capacity) -> b
         PyErr_NoMemory();
         return false;
     }
-    m_read_buffer = std::span<int8_t>(m_read_buffer_mem_owner, buf_capacity);
+    m_read_buffer = std::span<int8_t>{m_read_buffer_mem_owner, static_cast<size_t>(buf_capacity)};
     m_input_ir_stream = input_stream;
     Py_INCREF(m_input_ir_stream);
     return true;
@@ -242,7 +242,7 @@ auto PyDecoderBuffer::populate_read_buffer(Py_ssize_t& num_bytes_read) -> bool {
             PyErr_NoMemory();
             return false;
         }
-        std::span<int8_t> new_read_buffer{new_buf, static_cast<size_t>(new_capacity)};
+        std::span<int8_t> const new_read_buffer{new_buf, static_cast<size_t>(new_capacity)};
         std::copy(
                 unconsumed_bytes_in_curr_read_buffer.begin(),
                 unconsumed_bytes_in_curr_read_buffer.end(),

--- a/src/clp_ffi_py/ir/native/PyDecoderBuffer.hpp
+++ b/src/clp_ffi_py/ir/native/PyDecoderBuffer.hpp
@@ -3,8 +3,9 @@
 
 #include <clp_ffi_py/Python.hpp>  // Must always be included before any other header files
 
+#include <span>
+
 #include <clp/components/core/src/ffi/ir_stream/decoding_methods.hpp>
-#include <gsl/span>
 
 #include <clp_ffi_py/ir/native/PyMetadata.hpp>
 #include <clp_ffi_py/PyObjectUtils.hpp>
@@ -102,7 +103,7 @@ public:
     /**
      * @return A span containing unconsumed bytes.
      */
-    [[nodiscard]] auto get_unconsumed_bytes() const -> gsl::span<int8_t> {
+    [[nodiscard]] auto get_unconsumed_bytes() const -> std::span<int8_t> {
         return m_read_buffer.subspan(m_num_current_bytes_consumed, get_num_unconsumed_bytes());
     }
 
@@ -214,7 +215,7 @@ private:
     PyObject* m_input_ir_stream;
     PyMetadata* m_metadata;
     int8_t* m_read_buffer_mem_owner;
-    gsl::span<int8_t> m_read_buffer;
+    std::span<int8_t> m_read_buffer;
     ffi::epoch_time_ms_t m_ref_timestamp;
     Py_ssize_t m_buffer_size;
     Py_ssize_t m_num_current_bytes_consumed;

--- a/src/clp_ffi_py/ir/native/decoding_methods.cpp
+++ b/src/clp_ffi_py/ir/native/decoding_methods.cpp
@@ -2,11 +2,12 @@
 
 #include "decoding_methods.hpp"
 
+#include <span>
+
 #include <clp/components/core/src/BufferReader.hpp>
 #include <clp/components/core/src/ffi/ir_stream/decoding_methods.hpp>
 #include <clp/components/core/src/ffi/ir_stream/protocol_constants.hpp>
 #include <clp/components/core/src/type_utils.hpp>
-#include <gsl/span>
 #include <json/single_include/nlohmann/json.hpp>
 
 #include <clp_ffi_py/error_messages.hpp>
@@ -191,8 +192,9 @@ auto decode_preamble(PyObject* Py_UNUSED(self), PyObject* py_decoder_buffer) -> 
         nlohmann::json const metadata_json(
                 nlohmann::json::parse(metadata_buffer.begin(), metadata_buffer.end())
         );
-        std::string const version{metadata_json.at(ffi::ir_stream::cProtocol::Metadata::VersionKey)
-        };
+        std::string const version{metadata_json.at(
+                static_cast<char const*>(ffi::ir_stream::cProtocol::Metadata::VersionKey)
+        )};
         auto const error_code{ffi::ir_stream::validate_protocol_version(version)};
         if (ffi::ir_stream::IRProtocolErrorCode_Supported != error_code) {
             switch (error_code) {


### PR DESCRIPTION
# Description
This PR upgrades the C++ standard from C++17 to C++20. With C++20 enabled, gsl::span can be now replaced by std::span.
