### PR TITLE
Add support to skip forward when decoding IR streams

### DIFF
--- a/clp_ffi_py/ir/native.pyi
+++ b/clp_ffi_py/ir/native.pyi
@@ -79,5 +79,11 @@ class Decoder:
         query: Optional[Query] = None,
         allow_incomplete_stream: bool = False,
     ) -> Optional[LogEvent]: ...
+    @staticmethod
+    def skip_next_n_log_events(
+        decoder_buffer: DecoderBuffer,
+        num_events_to_skip: int,
+        allow_incomplete_stream: bool = False,
+    ) -> None: ...
 
 class IncompleteStreamError(Exception): ...

--- a/clp_ffi_py/ir/native.pyi
+++ b/clp_ffi_py/ir/native.pyi
@@ -80,7 +80,7 @@ class Decoder:
         allow_incomplete_stream: bool = False,
     ) -> Optional[LogEvent]: ...
     @staticmethod
-    def skip_next_n_log_events(
+    def skip_forward(
         decoder_buffer: DecoderBuffer,
         num_events_to_skip: int,
         allow_incomplete_stream: bool = False,

--- a/clp_ffi_py/ir/readers.py
+++ b/clp_ffi_py/ir/readers.py
@@ -100,6 +100,15 @@ class ClpIrStreamReader(Iterator[LogEvent]):
                 break
             yield log_event
 
+    def skip_forward(self, num_events_to_skip: int) -> None:
+        """
+        Decodes and discards the next `num_events_to_skip` log events from the
+        underlying IR stream.
+
+        :param: num_events_to_skip
+        """
+        Decoder.skip_forward(self._decoder_buffer, num_events_to_skip)
+
     def close(self) -> None:
         self.__istream.close()
 

--- a/src/clp_ffi_py/ir/native/PyDecoder.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoder.cpp
@@ -44,6 +44,24 @@ PyDoc_STRVAR(
 );
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+PyDoc_STRVAR(
+        cSkipNextNLogEventsDoc,
+        "skip_next_n_log_events( "
+        "decoder_buffer, num_events_to_skip, allow_incomplete_stream=False)\n"
+        "--\n\n"
+        "Decodes and discard the next n log events from the IR stream buffered in the given "
+        "decoder buffer. `decoder_buffer` must have been returned by a successfully invocation of "
+        "`decode_preamble`. It will stop whenever EOF.\n\n"
+        ":param decoder_buffer: The decoder buffer of the encoded CLP IR stream.\n"
+        ":param num_events_to_skip: Number of events to skip forward.\n"
+        ":param allow_incomplete_stream: If set to `True`, an incomplete CLP IR stream is not "
+        "treated as an error. Instead, encountering such a stream is seen as reaching its end, and "
+        "the function will return None without raising any exceptions.\n"
+        ":raises: Appropriate exceptions with detailed information on any encountered failure.\n"
+        ":return: None\n"
+);
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyMethodDef PyDecoder_method_table[]{
         {"decode_preamble",
          decode_preamble,
@@ -54,6 +72,11 @@ PyMethodDef PyDecoder_method_table[]{
          py_c_function_cast(decode_next_log_event),
          METH_VARARGS | METH_KEYWORDS | METH_STATIC,
          static_cast<char const*>(cDecodeNextLogEventDoc)},
+
+        {"skip_next_n_log_events",
+         py_c_function_cast(skip_next_n_log_events),
+         METH_VARARGS | METH_KEYWORDS | METH_STATIC,
+         static_cast<char const*>(cSkipNextNLogEventsDoc)},
 
         {nullptr, nullptr, 0, nullptr}
 };

--- a/src/clp_ffi_py/ir/native/PyDecoder.cpp
+++ b/src/clp_ffi_py/ir/native/PyDecoder.cpp
@@ -45,13 +45,13 @@ PyDoc_STRVAR(
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
-        cSkipNextNLogEventsDoc,
-        "skip_next_n_log_events( "
+        cSkipForwardDoc,
+        "skip_forward( "
         "decoder_buffer, num_events_to_skip, allow_incomplete_stream=False)\n"
         "--\n\n"
-        "Decodes and discard the next n log events from the IR stream buffered in the given "
-        "decoder buffer. `decoder_buffer` must have been returned by a successfully invocation of "
-        "`decode_preamble`. It will stop whenever EOF.\n\n"
+        "Decodes and discards the given amount of log events from the IR stream buffered in the "
+        "given decoder buffer. `decoder_buffer` must have been returned by a successfully "
+        "invocation of `decode_preamble`. It will stop whenever EOF.\n\n"
         ":param decoder_buffer: The decoder buffer of the encoded CLP IR stream.\n"
         ":param num_events_to_skip: Number of events to skip forward.\n"
         ":param allow_incomplete_stream: If set to `True`, an incomplete CLP IR stream is not "
@@ -73,10 +73,10 @@ PyMethodDef PyDecoder_method_table[]{
          METH_VARARGS | METH_KEYWORDS | METH_STATIC,
          static_cast<char const*>(cDecodeNextLogEventDoc)},
 
-        {"skip_next_n_log_events",
-         py_c_function_cast(skip_next_n_log_events),
+        {"skip_forward",
+         py_c_function_cast(skip_forward),
          METH_VARARGS | METH_KEYWORDS | METH_STATIC,
-         static_cast<char const*>(cSkipNextNLogEventsDoc)},
+         static_cast<char const*>(cSkipForwardDoc)},
 
         {nullptr, nullptr, 0, nullptr}
 };

--- a/src/clp_ffi_py/ir/native/PyLogEvent.cpp
+++ b/src/clp_ffi_py/ir/native/PyLogEvent.cpp
@@ -503,7 +503,7 @@ auto PyLogEvent::module_level_init(PyObject* py_module) -> bool {
 }
 
 auto PyLogEvent::create_new_log_event(
-        std::string const& log_message,
+        std::string_view log_message,
         ffi::epoch_time_ms_t timestamp,
         size_t index,
         PyMetadata* metadata

--- a/src/clp_ffi_py/ir/native/PyLogEvent.hpp
+++ b/src/clp_ffi_py/ir/native/PyLogEvent.hpp
@@ -133,7 +133,7 @@ public:
      * set.
      */
     [[nodiscard]] static auto create_new_log_event(
-            std::string const& log_message,
+            std::string_view log_message,
             ffi::epoch_time_ms_t timestamp,
             size_t index,
             PyMetadata* metadata

--- a/src/clp_ffi_py/ir/native/decoding_methods.cpp
+++ b/src/clp_ffi_py/ir/native/decoding_methods.cpp
@@ -328,8 +328,7 @@ auto decode_next_log_event(PyObject* Py_UNUSED(self), PyObject* args, PyObject* 
     );
 }
 
-auto skip_next_n_log_events(PyObject* Py_UNUSED(self), PyObject* args, PyObject* keywords)
-        -> PyObject* {
+auto skip_forward(PyObject* Py_UNUSED(self), PyObject* args, PyObject* keywords) -> PyObject* {
     static char keyword_decoder_buffer[]{"decoder_buffer"};
     static char keyword_num_events_to_skip[]{"num_events_to_skip"};
     static char keyword_allow_incomplete_stream[]{"allow_incomplete_stream"};

--- a/src/clp_ffi_py/ir/native/decoding_methods.cpp
+++ b/src/clp_ffi_py/ir/native/decoding_methods.cpp
@@ -25,19 +25,19 @@ namespace {
 /**
  * Decodes the next log event from the CLP IR buffer `decoder_buffer` until
  * terminate handler returns true.
+ * @tparam TerminateHandler Method to determine if the decoding should
+ * terminate, and set the return value for termination.
+ * Signature: (
+ *         [maybe_unused] ffi::epoch_timestamp_ms timestamp,
+ *         [maybe_unused] std::string_view decoded_log_message,
+ *         [maybe_unused] size_t decoded_log_event_idx,
+ *         PyObject*& return_value
+ * ) -> bool;
  * @param decoder_buffer IR decoder buffer of the input IR stream.
  * @param allow_incomplete_stream A flag to indicate whether the incomplete
  * stream error should be ignored. If it is set to true, incomplete stream error
  * should be treated as the termination.
- * @param terminate_handler Determine if the decoding process should terminate
- * after decoding the current log event and set the return value if terminating.
- * Signature:
- * [] (
- *         ffi::epoch_timestamp_ms timestamp,
- *         std::string_view log_message,
- *         size_t log_event_idx,
- *         PyObject*& return_value
- * ) -> bool;
+ * @param terminate_handler
  * @return The return value set by `terminate_handler`.
  * @return nullptr on failure with the relevant Python exception and error set.
  */

--- a/src/clp_ffi_py/ir/native/decoding_methods.hpp
+++ b/src/clp_ffi_py/ir/native/decoding_methods.hpp
@@ -9,6 +9,7 @@ namespace clp_ffi_py::ir::native {
 extern "C" {
 auto decode_preamble(PyObject* self, PyObject* py_decoder_buffer) -> PyObject*;
 auto decode_next_log_event(PyObject* self, PyObject* args, PyObject* keywords) -> PyObject*;
+auto skip_next_n_log_events(PyObject* self, PyObject* args, PyObject* keywords) -> PyObject*;
 }
 }  // namespace clp_ffi_py::ir::native
 

--- a/src/clp_ffi_py/ir/native/decoding_methods.hpp
+++ b/src/clp_ffi_py/ir/native/decoding_methods.hpp
@@ -9,7 +9,7 @@ namespace clp_ffi_py::ir::native {
 extern "C" {
 auto decode_preamble(PyObject* self, PyObject* py_decoder_buffer) -> PyObject*;
 auto decode_next_log_event(PyObject* self, PyObject* args, PyObject* keywords) -> PyObject*;
-auto skip_next_n_log_events(PyObject* self, PyObject* args, PyObject* keywords) -> PyObject*;
+auto skip_forward(PyObject* self, PyObject* args, PyObject* keywords) -> PyObject*;
 }
 }  // namespace clp_ffi_py::ir::native
 

--- a/tests/test_ir/test_decoder.py
+++ b/tests/test_ir/test_decoder.py
@@ -51,7 +51,7 @@ class TestCaseDecoderSkip(TestCLPBase):
         _ = Decoder.decode_preamble(decoder_buffer)
         error_captured: bool = False
         try:
-            Decoder.skip_next_n_log_events(decoder_buffer, -1)
+            Decoder.skip_forward(decoder_buffer, -1)
         except NotImplementedError:
             error_captured = True
         except Exception as e:
@@ -67,7 +67,7 @@ class TestCaseDecoderSkip(TestCLPBase):
         decoder_buffer: DecoderBuffer = DecoderBuffer(ir_stream)
         _ = Decoder.decode_preamble(decoder_buffer)
         for i in range(num_events):
-            Decoder.skip_next_n_log_events(decoder_buffer, 0)
+            Decoder.skip_forward(decoder_buffer, 0)
             log_event: Optional[LogEvent] = Decoder.decode_next_log_event(decoder_buffer)
             if None is log_event:
                 self.assertTrue(False, "EOF shouldn't be reached before all log events are decoded")
@@ -85,7 +85,7 @@ class TestCaseDecoderSkip(TestCLPBase):
         ir_stream: IO[bytes] = self._create_simple_encoded_IR_stream(1)
         decoder_buffer: DecoderBuffer = DecoderBuffer(ir_stream)
         _ = Decoder.decode_preamble(decoder_buffer)
-        Decoder.skip_next_n_log_events(decoder_buffer, 1000)
+        Decoder.skip_forward(decoder_buffer, 1000)
         eof: Optional[LogEvent] = Decoder.decode_next_log_event(decoder_buffer)
         self.assertEqual(None, eof, "EOF should be reached since all the log events are decoded")
 
@@ -106,7 +106,7 @@ class TestCaseDecoderSkip(TestCLPBase):
         num_events_decoded: int = 0
         for i in range(num_arithmetic_sequence_term):
             term_idx = i + 1
-            Decoder.skip_next_n_log_events(decoder_buffer, term_idx)
+            Decoder.skip_forward(decoder_buffer, term_idx)
             num_events_skipped += term_idx
             for _ in range(term_idx):
                 log_event: Optional[LogEvent] = Decoder.decode_next_log_event(decoder_buffer)

--- a/tests/test_ir/test_decoder.py
+++ b/tests/test_ir/test_decoder.py
@@ -1,6 +1,7 @@
+import io
 import random
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import IO, List, Optional, Tuple
 
 from smart_open import open  # type: ignore
 from test_ir.test_utils import get_current_timestamp, LogGenerator, TestCLPBase
@@ -16,6 +17,116 @@ from clp_ffi_py.ir import (
 from clp_ffi_py.wildcard_query import WildcardQuery
 
 LOG_DIR: Path = Path("unittest-logs")
+
+
+class TestCaseDecoderSkip(TestCLPBase):
+    """
+    Class for testing the skip method(s) of clp_ffi_py.ir.Decoder.
+    """
+
+    def _create_simple_encoded_IR_stream(self, num_events: int) -> IO[bytes]:
+        """
+        Creates a simple IR stream that contains `num_events` of log events. The
+        content of each message is set to "Message".
+
+        :param num_events
+        :return: A byte stream that contains the encoded CLP IR stream.
+        """
+        ir_stream: IO[bytes] = io.BytesIO()
+        ir_stream.write(FourByteEncoder.encode_preamble(0, "", "America/New_York"))
+        for _ in range(num_events):
+            ir_stream.write(
+                FourByteEncoder.encode_message_and_timestamp_delta(0, "Message".encode())
+            )
+        ir_stream.write(FourByteEncoder.encode_end_of_ir())
+        ir_stream.seek(0)
+        return ir_stream
+
+    def test_skip_negative_num_events(self) -> None:
+        """
+        Tests skipping with a negative number of events.
+        """
+        ir_stream: IO[bytes] = self._create_simple_encoded_IR_stream(1)
+        decoder_buffer: DecoderBuffer = DecoderBuffer(ir_stream)
+        _ = Decoder.decode_preamble(decoder_buffer)
+        error_captured: bool = False
+        try:
+            Decoder.skip_next_n_log_events(decoder_buffer, -1)
+        except NotImplementedError:
+            error_captured = True
+        except Exception as e:
+            self.assertTrue(False, f"Unexpected exception captured: {e}")
+        self.assertTrue(error_captured, "Negative input should raise an `NotImplemented` exception")
+
+    def test_skip_zero_event(self) -> None:
+        """
+        Tests skipping with a `0` as the input.
+        """
+        num_events: int = 10
+        ir_stream: IO[bytes] = self._create_simple_encoded_IR_stream(10)
+        decoder_buffer: DecoderBuffer = DecoderBuffer(ir_stream)
+        _ = Decoder.decode_preamble(decoder_buffer)
+        for i in range(num_events):
+            Decoder.skip_next_n_log_events(decoder_buffer, 0)
+            log_event: Optional[LogEvent] = Decoder.decode_next_log_event(decoder_buffer)
+            if None is log_event:
+                self.assertTrue(False, "EOF shouldn't be reached before all log events are decoded")
+            assert None is not log_event  # Silence mypy check
+            decoded_idx: int = log_event.get_index()
+            self.assertEqual(i, decoded_idx, f"Expected idx: {i}, Decoded idx: {decoded_idx}")
+        eof: Optional[LogEvent] = Decoder.decode_next_log_event(decoder_buffer)
+        self.assertEqual(None, eof, "EOF should be reached since all the log events are decoded")
+
+    def test_skip_to_eof(self) -> None:
+        """
+        Tests skipping with a number larger than the total number of events in
+        the stream.
+        """
+        ir_stream: IO[bytes] = self._create_simple_encoded_IR_stream(1)
+        decoder_buffer: DecoderBuffer = DecoderBuffer(ir_stream)
+        _ = Decoder.decode_preamble(decoder_buffer)
+        Decoder.skip_next_n_log_events(decoder_buffer, 1000)
+        eof: Optional[LogEvent] = Decoder.decode_next_log_event(decoder_buffer)
+        self.assertEqual(None, eof, "EOF should be reached since all the log events are decoded")
+
+    def test_skip_general(self) -> None:
+        """
+        Tests skipping in general.
+        """
+        num_arithmetic_sequence_term: int = 10
+        arithmetic_sequence_sum: int = 0
+        for i in range(num_arithmetic_sequence_term):
+            arithmetic_sequence_sum += i + 1
+        num_events = arithmetic_sequence_sum * 2
+
+        ir_stream: IO[bytes] = self._create_simple_encoded_IR_stream(num_events)
+        decoder_buffer: DecoderBuffer = DecoderBuffer(ir_stream)
+        _ = Decoder.decode_preamble(decoder_buffer)
+        num_events_skipped: int = 0
+        num_events_decoded: int = 0
+        for i in range(num_arithmetic_sequence_term):
+            term_idx = i + 1
+            Decoder.skip_next_n_log_events(decoder_buffer, term_idx)
+            num_events_skipped += term_idx
+            for _ in range(term_idx):
+                log_event: Optional[LogEvent] = Decoder.decode_next_log_event(decoder_buffer)
+                if None is log_event:
+                    self.assertTrue(
+                        False, "EOF shouldn't be reached before all log events are decoded"
+                    )
+                assert None is not log_event  # Silence mypy check
+                decoded_idx: int = log_event.get_index()
+                expected_idx: int = num_events_decoded + num_events_skipped
+                self.assertEqual(
+                    expected_idx,
+                    decoded_idx,
+                    f"Expected idx: {expected_idx}, Decoded idx: {decoded_idx}",
+                )
+                num_events_decoded += 1
+        eof: Optional[LogEvent] = Decoder.decode_next_log_event(decoder_buffer)
+        self.assertEqual(None, eof, "EOF should be reached since all the log events are decoded")
+        self.assertTrue(arithmetic_sequence_sum, num_events_decoded)
+        self.assertTrue(arithmetic_sequence_sum, num_events_skipped)
 
 
 class TestCaseDecoderBase(TestCLPBase):


### PR DESCRIPTION
# Description
Currently, the decoder doesn't support skipping forward. Users have to decode and discard log events when needed manually. This PR enables forward skipping by introducing a new method to decode and discard a certain amount of log events from the given IR stream.
This PR also refactors the implementation of the decoding method to template the termination of a decoding process. This provides a function interface to reuse decoding logic and implement query search decoding, sequential decoding, and forward skipping.

# Validation performed
1. Add new unit tests to verify the behavior of forward skipping.
2. Ensure all existing unit tests are passed after refactoring the decoding method.

