### PR TITLE
Lock smart_open to v6.4.0 to fix unit-test and Python3.6 build failures.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test-command = [
   "python -m unittest -fv",
 ]
 test-requires = [
-    "smart_open"
+    "smart_open==6.4.0"
 ]
 test-skip = [
     "cp37-*",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ mypy>=1.7.1
 mypy-extensions>=1.0.0
 packaging>=21.3
 ruff>=0.1.6
-smart_open==6.3.0
+smart_open==6.4.0
 toml>=0.10.2
 tomli>=2.0.1
 types-python-dateutil>=2.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ mypy>=1.7.1
 mypy-extensions>=1.0.0
 packaging>=21.3
 ruff>=0.1.6
-smart_open>=6.3.0
+smart_open==6.3.0
 toml>=0.10.2
 tomli>=2.0.1
 types-python-dateutil>=2.8


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
`smart-open` has released version 7.0.1. In this new version, they introduced `__future__` notations, which were not supported in Python3.6, thus causing the unit test failures. Also, it attempts to use the `_FileLikeProxy__inner` attributes of `zstd.ZstdCompressionWriter`, which does not exist. Therefore, we will lock `smart-open` to an earlier version to avoid unit test failures.

# Validation performed
<!-- What tests and validation you performed on the change -->

