### PR TITLE
Make macOS deployment target check robust against float precision errors.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -86,7 +86,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_ARCHS_LINUX: auto aarch64
-          MACOSX_DEPLOYMENT_TARGET: 10.15
 
       - uses: actions/upload-artifact@v3
         with:

--- a/setup.py
+++ b/setup.py
@@ -45,14 +45,14 @@ if "__main__" == __name__:
     try:
         if "Darwin" == platform.system():
             target_env_var_name: str = "MACOSX_DEPLOYMENT_TARGET"
-            required_target: Tuple[int, int] = (10, 15)
+            min_target_version: Tuple[int, int] = (10, 15)
             
             target_str: Optional[str] = os.environ.get(target_env_var_name)
             target: Tuple[int, ...] = ()
             if target_str is not None:
                 target = tuple(int(part) for part in target_str.split("."))
-            if target < required_target:
-                target = required_target
+            if target < min_target_version:
+                target = min_target_version
             os.environ[target_env_var_name] = ".".join(str(part) for part in target)
 
         project_name: str = "clp_ffi_py"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import platform
 import sys
 from setuptools import setup, Extension
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 ir_native: Extension = Extension(
     name="clp_ffi_py.ir.native",
@@ -44,16 +44,16 @@ ir_native: Extension = Extension(
 if "__main__" == __name__:
     try:
         if "Darwin" == platform.system():
-            target: Optional[str] = os.environ.get("MACOSX_DEPLOYMENT_TARGET")
-            env_setup_needed: bool = False
-            if None is target:
-                env_setup_needed = True
-            else:
-                version_values: List[int] = [int(part) for part in target.split(".")]
-                if 10 >= version_values[0] and 15 >= version_values[1]:
-                    env_setup_needed = True
-            if env_setup_needed:
-                os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"
+            target_env_var_name: str = "MACOSX_DEPLOYMENT_TARGET"
+            required_target: Tuple[int, int] = (10, 15)
+            
+            target_str: Optional[str] = os.environ.get(target_env_var_name)
+            target: Tuple[int, ...] = ()
+            if target_str is not None:
+                target = tuple(int(part) for part in target_str.split("."))
+            if target < required_target:
+                target = required_target
+            os.environ[target_env_var_name] = ".".join(str(part) for part in target)
 
         project_name: str = "clp_ffi_py"
         description: str = "CLP FFI Python Interface"

--- a/setup.py
+++ b/setup.py
@@ -45,14 +45,21 @@ if "__main__" == __name__:
     try:
         if "Darwin" == platform.system():
             target: Optional[str] = os.environ.get("MACOSX_DEPLOYMENT_TARGET")
-            if None is target or float(target) < 10.15:
+            env_setup_needed: bool = False
+            if None is target:
+                env_setup_needed = True
+            else:
+                version_values: List[int] = [int(part) for part in target.split(".")]
+                if 10 >= version_values[0] and 15 >= version_values[1]:
+                    env_setup_needed = True
+            if env_setup_needed:
                 os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"
 
         project_name: str = "clp_ffi_py"
         description: str = "CLP FFI Python Interface"
         extension_modules: List[Extension] = [ir_native]
         if (3, 7) > sys.version_info:
-            sys.exit(f"The minimum Python version required is Python3.7")
+            sys.exit("The minimum Python version required is Python3.7")
         else:
             setup(
                 name=project_name,


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
When building for MacOS, we used to compare the version by converting the version to a floating point, which didn't work in `cibuildwheel` environment. This PR properly extracts the major and minor versions and executes int comparison instead. By doing this, we no longer need to specify the env variable in the workflow. This will ensure the local build works in MacOS environment.

# Validation performed
<!-- What tests and validation you performed on the change -->
Validated workflow passed.

