### PR TITLE
Add support for compiling C-extension in parallel.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
+import distutils.ccompiler
+import multiprocessing.pool
 import os
 import platform
 import sys
 from setuptools import setup, Extension
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 ir_native: Extension = Extension(
     name="clp_ffi_py.ir.native",
@@ -41,6 +43,33 @@ ir_native: Extension = Extension(
     define_macros=[("SOURCE_PATH_SIZE", str(len(os.path.abspath("./src/clp/components/core"))))],
 )
 
+def _parallel_compile(
+    self: distutils.ccompiler.CCompiler,
+    sources: List[str],
+    output_dir: Optional[str] = None,
+    macros: Optional[List[Tuple[str, Optional[str]]]] = None,
+    include_dirs: Optional[List[str]] = None,
+    debug: int = 0,
+    extra_preargs: Optional[List[str]] = None,
+    extra_postargs: Optional[List[str]] = None,
+    depends: Optional[List[str]] = None,
+) -> List[str]:
+    macros, objects, extra_postargs, pp_opts, build = self._setup_compile(
+        output_dir, macros, include_dirs, sources, depends, extra_postargs
+    )
+    cc_args = self._get_cc_args(pp_opts, debug, extra_preargs)
+
+    def _compile_single_file(obj: str) -> None:
+        try:
+            src, ext = build[obj]
+        except KeyError:
+            return
+        self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
+
+    num_cores: int = multiprocessing.cpu_count()
+    multiprocessing.pool.ThreadPool(num_cores).map(_compile_single_file, objects)
+    return objects
+
 if "__main__" == __name__:
     try:
         if "Darwin" == platform.system():
@@ -48,6 +77,7 @@ if "__main__" == __name__:
             if None is target or float(target) < 10.15:
                 os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"
 
+        distutils.ccompiler.CCompiler.compile = _parallel_compile
         project_name: str = "clp_ffi_py"
         description: str = "CLP FFI Python Interface"
         extension_modules: List[Extension] = [ir_native]

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,10 @@ def _parallel_compile(
     extra_postargs: Optional[List[str]] = None,
     depends: Optional[List[str]] = None,
 ) -> List[str]:
+    """
+    A replacement for distutils.ccompiler.CCompiler.compile that compiles each source file
+    concurrently.
+    """
     macros, objects, extra_postargs, pp_opts, build = self._setup_compile(
         output_dir, macros, include_dirs, sources, depends, extra_postargs
     )

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ def _parallel_compile(
         self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
 
     num_cores: int = multiprocessing.cpu_count()
-    multiprocessing.pool.ThreadPool(num_cores).map(_compile_single_file, objects)
+    with multiprocessing.pool.ThreadPool(num_cores) as pool:
+        pool.map(_compile_single_file, objects)
     return objects
 
 if "__main__" == __name__:


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The native `setup.py` support doesn't provide a way to parallelize source compilation, making the compilation time very slow. This PR implements a patch to enable the parallel compilation by learning [grpc](https://github.com/grpc/grpc/blob/master/src/python/grpcio/_parallel_compile_patch.py) and [cpython](https://github.com/python/cpython/blob/31368a4f0e531c19affe2a1becd25fc316bc7501/Lib/distutils/ccompiler.py#L511C9-L511C16). Essentially, this PR implements a method that overloads the default `compile` method to use `multiprocessing` to compile files in parallel.

Local Benchmark:
When building for MacOS in M1 Pro (10 cores), the total compilation time (real-time) using `pip install -e .` is:
Serialized compilation (before this PR): 39.365s
Parallel compilation (after this PR): 11.709s
Improvements: 3.362x

Github Action Benchmark:
Unfortunately, Github Action only provides 2 cores in their virtual environment, so the improvements are not obvious. However, we can still see the improvements by comparing these two actions:
Serialized compilation (before this PR): https://github.com/y-scope/clp-ffi-py/actions/runs/8307187935
Parallel compilation (after this PR): https://github.com/LinZhihao-723/clp-ffi-py/actions/runs/8308605670
We may cherry-pick some builds to check the wheel building time:
cp38-manylinux_aarch64: 386.13s -> 223.95s
cp310-manylinux_i686: 41.50s -> 20.43s
cp311-macosx_arm64: 51.07s -> 22.02s
Note: the time in macos build doesn't have a stable improvement, which might be because the virtualized macos env doesn't have 2 physical cores.

# Validation performed
<!-- What tests and validation you performed on the change -->
Validated the workflow still passed.

