### PR TITLE
Move ruff lint settings into `tool.ruff.lint`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ exclude = [
     "clp_ffi_py/ir/__init__.py"
 ]
 line-length = 100
-select = ["E", "I", "F"]
 
-[tool.ruff.isort]
-order-by-type = false
+[tool.ruff.lint]
+select = ["E", "I", "F"]
+isort.order-by-type = false


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
When running the latest version of `ruff`, it will send the following warnings:
```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'select' -> 'lint.select'
  - 'isort' -> 'lint.isort
```
This PR solves the warning by updating the ruff settings in `pyproject.toml`.

# Validation performed
<!-- What tests and validation you performed on the change -->
1. Running `ruff` locally without warnings.
2. Workflow passed.

