### PR TITLE
linting: Always use latest versions of linting tools; Upgrade clang-format config.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -71,7 +71,7 @@ IncludeBlocks: "Regroup"
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
   # Python header must be included before any others
-  - Regex: "^<clp_ffi_py/Python\.hpp>$"
+  - Regex: "^<clp_ffi_py/Python\\.hpp>$"
     Priority: -1
   # Project headers
   - Regex: "^<clp_ffi_py"

--- a/.clang-format
+++ b/.clang-format
@@ -2,36 +2,39 @@
 ColumnLimit: 100
 IndentWidth: 4
 ---
-Language: Cpp
+Language: "Cpp"
 AccessModifierOffset: -4
-AlignAfterOpenBracket: BlockIndent
-AlignArrayOfStructures: None
-AlignConsecutiveAssignments: None
-AlignConsecutiveBitFields: None
-AlignConsecutiveDeclarations: None
-AlignConsecutiveMacros: None
-AlignEscapedNewlines: DontAlign
-AlignOperands: Align
-AlignTrailingComments: Never
+AlignAfterOpenBracket: "BlockIndent"
+AlignArrayOfStructures: "None"
+AlignConsecutiveAssignments: "None"
+AlignConsecutiveBitFields: "None"
+AlignConsecutiveDeclarations: "None"
+AlignConsecutiveMacros: "None"
+AlignEscapedNewlines: "DontAlign"
+AlignOperands: "Align"
+AlignTrailingComments:
+  Kind: "Never"
 AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: Always
+AllowBreakBeforeNoexceptSpecifier: "OnlyWithParen"
+AllowShortBlocksOnASingleLine: "Always"
 AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
 AllowShortEnumsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
-AllowShortIfStatementsOnASingleLine: Never
-AllowShortLambdasOnASingleLine: All
+AllowShortFunctionsOnASingleLine: "Inline"
+AllowShortIfStatementsOnASingleLine: "Never"
+AllowShortLambdasOnASingleLine: "All"
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterReturnType: None
+AlwaysBreakAfterReturnType: "None"
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: Yes
+AlwaysBreakTemplateDeclarations: "Yes"
 BinPackArguments: false
 BinPackParameters: false
-BitFieldColonSpacing: Both
+BitFieldColonSpacing: "Both"
 BraceWrapping:
   AfterCaseLabel: false
   AfterClass: false
-  AfterControlStatement: MultiLine
+  AfterControlStatement: "MultiLine"
   AfterEnum: false
   AfterFunction: false
   AfterNamespace: false
@@ -46,14 +49,14 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyNamespace: false
   SplitEmptyRecord: false
-BreakAfterAttributes: Never
-BreakBeforeBinaryOperators: All
-BreakBeforeBraces: Custom
-BreakBeforeConceptDeclarations: Always
-BreakBeforeInlineASMColon: OnlyMultiline
+BreakAfterAttributes: "Never"
+BreakBeforeBinaryOperators: "All"
+BreakBeforeBraces: "Custom"
+BreakBeforeConceptDeclarations: "Always"
+BreakBeforeInlineASMColon: "OnlyMultiline"
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeColon
-BreakInheritanceList: BeforeColon
+BreakConstructorInitializers: "BeforeColon"
+BreakInheritanceList: "BeforeColon"
 BreakStringLiterals: true
 CompactNamespaces: true
 ConstructorInitializerIndentWidth: 8
@@ -61,10 +64,10 @@ ContinuationIndentWidth: 8
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat: false
-EmptyLineAfterAccessModifier: Never
-EmptyLineBeforeAccessModifier: LogicalBlock
+EmptyLineAfterAccessModifier: "Never"
+EmptyLineBeforeAccessModifier: "LogicalBlock"
 FixNamespaceComments: true
-IncludeBlocks: Regroup
+IncludeBlocks: "Regroup"
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
   # Python header must be included before any others
@@ -87,9 +90,9 @@ IncludeCategories:
 IndentAccessModifiers: false
 IndentCaseBlocks: false
 IndentCaseLabels: true
-IndentExternBlock: NoIndent
+IndentExternBlock: "NoIndent"
 IndentGotoLabels: false
-IndentPPDirectives: BeforeHash
+IndentPPDirectives: "BeforeHash"
 IndentRequiresClause: false
 IndentWrappedFunctionNames: false
 InsertBraces: true
@@ -102,60 +105,62 @@ IntegerLiteralSeparator:
   Hex: 4
   HexMinDigits: 4
 KeepEmptyLinesAtTheStartOfBlocks: false
-LambdaBodyIndentation: Signature
-LineEnding: LF
+LambdaBodyIndentation: "Signature"
+LineEnding: "LF"
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
+NamespaceIndentation: "None"
 PPIndentWidth: -1
-PackConstructorInitializers: CurrentLine
+PackConstructorInitializers: "CurrentLine"
 PenaltyBreakOpenParenthesis: 25
 PenaltyBreakBeforeFirstCallParameter: 25
 PenaltyReturnTypeOnItsOwnLine: 100
-PointerAlignment: Left
-QualifierAlignment: Custom
+PointerAlignment: "Left"
+QualifierAlignment: "Custom"
 QualifierOrder:
-  - static
-  - friend
-  - inline
+  - "static"
+  - "friend"
+  - "inline"
   # constexpr west as explained in https://www.youtube.com/watch?v=z6s6bacI424
-  - constexpr
-  - type
-  - const
-  - volatile
-ReferenceAlignment: Pointer
+  - "constexpr"
+  - "type"
+  - "const"
+  - "volatile"
+ReferenceAlignment: "Pointer"
 ReflowComments: true
 RemoveBracesLLVM: false
 RemoveSemicolon: true
-RequiresClausePosition: OwnLine
-RequiresExpressionIndentation: OuterScope
-SeparateDefinitionBlocks: Always
+RequiresClausePosition: "OwnLine"
+RequiresExpressionIndentation: "OuterScope"
+SeparateDefinitionBlocks: "Always"
 ShortNamespaceLines: 0
-SortIncludes: CaseInsensitive
-SortUsingDeclarations: Lexicographic
+SortIncludes: "CaseInsensitive"
+SortUsingDeclarations: "Lexicographic"
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
-SpaceAroundPointerQualifiers: Default
+SpaceAroundPointerQualifiers: "Default"
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatements
+SpaceBeforeParens: "ControlStatements"
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
-SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
 SpacesInAngles: false
-SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false
-SpacesInCStyleCastParentheses: false
 SpacesInLineCommentPrefix:
   Minimum: 1
   Maximum: -1
-SpacesInParentheses: false
+SpacesInParens: "Custom"
+SpacesInParensOptions:
+  InConditionalStatements: false
+  InCStyleCasts: false
+  InEmptyParentheses: false
+  Other: false
 SpacesInSquareBrackets: false
-Standard: Latest
+Standard: "Latest"
 TabWidth: 4
-UseTab: Never
+UseTab: "Never"

--- a/.clang-format
+++ b/.clang-format
@@ -71,21 +71,21 @@ IncludeBlocks: "Regroup"
 IncludeCategories:
   # NOTE: A header is grouped by first matching regex
   # Python header must be included before any others
-  - Regex: '^<clp_ffi_py/Python\.hpp>$'
+  - Regex: "^<clp_ffi_py/Python\.hpp>$"
     Priority: -1
   # Project headers
-  - Regex: '^<clp_ffi_py'
+  - Regex: "^<clp_ffi_py"
     Priority: 4
   # Third-party headers. Update when adding new third-party library
-  - Regex: '^<(clp)'
+  - Regex: "^<(clp)"
     Priority: 3
-  - Regex: '<(json)'
+  - Regex: "<(json)"
     Priority: 3
   # C headers
-  - Regex: '^<.*.h>$'
+  - Regex: "^<.*.h>$"
     Priority: 1
   # C++ standard libraries
-  - Regex: '^<.*>$'
+  - Regex: "^<.*>$"
     Priority: 2
 IndentAccessModifiers: false
 IndentCaseBlocks: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,21 +24,21 @@ WarningsAsErrors: >-
 
 FormatStyle: file
 CheckOptions:
-  readability-identifier-naming.ClassCase: 'CamelCase'
-  readability-identifier-naming.ClassMemberCase: 'lower_case'
-  readability-identifier-naming.ClassMemberPrefix: 'm_'
-  readability-identifier-naming.ClassMethodCase: 'lower_case'
-  readability-identifier-naming.ConstexprVariableCase: 'CamelCase'
-  readability-identifier-naming.ConstexprVariablePrefix: 'c'
-  readability-identifier-naming.EnumCase: 'CamelCase'
-  readability-identifier-naming.EnumConstantCase: 'CamelCase'
-  readability-identifier-naming.GlobalConstantCase: 'CamelCase'
-  readability-identifier-naming.GlobalConstantPrefix: 'c'
-  readability-identifier-naming.LocalVariableCase: 'lower_case'
-  readability-identifier-naming.MemberCase: 'lower_case'
-  readability-identifier-naming.MemberPrefix: 'm_'
-  readability-identifier-naming.MethodCase: 'lower_case'
-  readability-identifier-naming.ParameterCase: 'lower_case'
-  readability-identifier-naming.StructCase: 'CamelCase'
-  readability-identifier-naming.TypedefCase: 'CamelCase'
-  readability-identifier-naming.UnionCase: 'CamelCase'
+  readability-identifier-naming.ClassCase: "CamelCase"
+  readability-identifier-naming.ClassMemberCase: "lower_case"
+  readability-identifier-naming.ClassMemberPrefix: "m_"
+  readability-identifier-naming.ClassMethodCase: "lower_case"
+  readability-identifier-naming.ConstexprVariableCase: "CamelCase"
+  readability-identifier-naming.ConstexprVariablePrefix: "c"
+  readability-identifier-naming.EnumCase: "CamelCase"
+  readability-identifier-naming.EnumConstantCase: "CamelCase"
+  readability-identifier-naming.GlobalConstantCase: "CamelCase"
+  readability-identifier-naming.GlobalConstantPrefix: "c"
+  readability-identifier-naming.LocalVariableCase: "lower_case"
+  readability-identifier-naming.MemberCase: "lower_case"
+  readability-identifier-naming.MemberPrefix: "m_"
+  readability-identifier-naming.MethodCase: "lower_case"
+  readability-identifier-naming.ParameterCase: "lower_case"
+  readability-identifier-naming.StructCase: "CamelCase"
+  readability-identifier-naming.TypedefCase: "CamelCase"
+  readability-identifier-naming.UnionCase: "CamelCase"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
-black>=23.11.0
+black>=24.4.2
 build>=0.8.0
 cibuildwheel>=2.16.2
-clang-format>=17.0.5
+clang-format>=18.1.5
 docformatter>=1.7.5
-mypy>=1.7.1
+mypy>=1.10.0
 mypy-extensions>=1.0.0
 packaging>=21.3
-ruff>=0.1.6
+ruff>=0.4.6
 smart_open==6.4.0
 types-python-dateutil>=2.8
 zstandard>=0.18.0

--- a/src/clp_ffi_py/ir/native/Query.hpp
+++ b/src/clp_ffi_py/ir/native/Query.hpp
@@ -26,7 +26,7 @@ public:
      */
     WildcardQuery(std::string wildcard_query, bool case_sensitive)
             : m_wildcard_query(std::move(wildcard_query)),
-              m_case_sensitive(case_sensitive){};
+              m_case_sensitive(case_sensitive) {};
 
     [[nodiscard]] auto get_wildcard_query() const -> std::string const& { return m_wildcard_query; }
 


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The current code base was formatted by out-dated linting tools. When running gh workflow, linting check will fail. This PR has the following updates:
- Update all linting tools to the latest pypi released versions.
- Update clang-format config with new features added in version 18. In addition, format yaml file to match CLP core style. Please check this PR for more details: https://github.com/y-scope/clp/pull/384
- Refactor everything after upgrading linter versions.
Note: ideally, we can drop the versions specified in `requirements-dev.txt` to ensure it always uses the latest one. However, adding the version there would help us keep track of which version of the config file we used to setup these linting tools.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensured workflow passed.
