### PR TITLE
Add more explicit interface to differentiate substring and full-string wildcard queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,16 @@ from pathlib import Path
 from typing import List, Tuple
 
 from clp_ffi_py.ir import ClpIrFileReader, Query, QueryBuilder
+from clp_ffi_py.wildcard_query import FullStringWildcardQuery, SubstringWildcardQuery
 
 # Create a QueryBuilder object to build the search query.
 query_builder: QueryBuilder = QueryBuilder()
 
 # Add wildcard patterns to filter log messages:
-query_builder.add_wildcard_query("*uid=*,status=failed*")
-query_builder.add_wildcard_query("*UID=*,Status=KILLED*", case_sensitive=True)
+query_builder.add_wildcard_query(SubstringWildcardQuery("uid=*,status=failed"))
+query_builder.add_wildcard_query(
+    FullStringWildcardQuery("*UID=*,Status=KILLED*", case_sensitive=True)
+)
 
 # Initialize a Query object using the builder:
 wildcard_search_query: Query = query_builder.build()
@@ -169,10 +172,12 @@ details, use the following code to access the related docstring.
 
 ```python
 from clp_ffi_py.ir import Query, QueryBuilder
-from clp_ffi_py import WildcardQuery
+from clp_ffi_py import FullStringWildcardQuery, SubstringWildcardQuery, WildcardQuery
 help(Query)
 help(QueryBuilder)
 help(WildcardQuery)
+help(FullStringWildcardQuery)
+help(SubstringWildcardQuery)
 ```
 
 ### Streaming Decode/Search Directly from S3 Remote Storage

--- a/clp_ffi_py/ir/query_builder.py
+++ b/clp_ffi_py/ir/query_builder.py
@@ -117,9 +117,6 @@ class QueryBuilder:
     ) -> QueryBuilder:
         """
         This method is the implementation of `add_wildcard_query`.
-
-        Type check is disabled since it executes runtime checks to ensure
-        passed-in arguments match the defined signatures.
         """
         if isinstance(wildcard_query, WildcardQuery):
             self._wildcard_queries.append(wildcard_query)

--- a/clp_ffi_py/ir/query_builder.py
+++ b/clp_ffi_py/ir/query_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from copy import deepcopy
 from typing import Any, Dict, List, no_type_check, Optional, overload, Tuple, Union
 
@@ -7,6 +8,10 @@ from deprecated.sphinx import deprecated
 
 from clp_ffi_py.ir.native import Query
 from clp_ffi_py.wildcard_query import FullStringWildcardQuery, WildcardQuery
+
+_add_wildcard_query_deprecation_warning_message: str = "The wildcard query must be explicitly "
+"created and passed as a parameter to this function. QueryBuilder should only accept instances of "
+"`clp_ffi_py.wildcard_query.WildcardQuery`."
 
 
 class QueryBuilderException(Exception):
@@ -83,9 +88,7 @@ class QueryBuilder:
     @overload
     @deprecated(
         version="0.0.12",
-        reason="The wildcard query must be explicitly created and passed as a parameter to this"
-        " function. QueryBuilder should only accept instances of"
-        " `clp_ffi_py.wildcard_query.WildcardQuery`.",
+        reason=_add_wildcard_query_deprecation_warning_message,
     )
     def add_wildcard_query(self, wildcard_query: str, case_sensitive: bool = False) -> QueryBuilder:
         """
@@ -125,6 +128,10 @@ class QueryBuilder:
             if isinstance(wildcard_query, WildcardQuery):
                 self._wildcard_queries.append(wildcard_query)
             elif isinstance(wildcard_query, str):
+                warnings.warn(
+                    _add_wildcard_query_deprecation_warning_message,
+                    DeprecationWarning,
+                )
                 self._wildcard_queries.append(FullStringWildcardQuery(wildcard_query, False))
             else:
                 raise TypeError
@@ -140,6 +147,10 @@ class QueryBuilder:
                 case_sensitive = kwargs["case_sensitive"]
             if not (isinstance(wildcard_query, str) and isinstance(case_sensitive, bool)):
                 raise TypeError
+            warnings.warn(
+                _add_wildcard_query_deprecation_warning_message,
+                DeprecationWarning,
+            )
             self._wildcard_queries.append(FullStringWildcardQuery(wildcard_query, case_sensitive))
             return self
         raise NotImplementedError

--- a/clp_ffi_py/ir/query_builder.py
+++ b/clp_ffi_py/ir/query_builder.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from copy import deepcopy
-from typing import Any, Dict, List, no_type_check, Optional, overload, Tuple, Union
+from typing import List, Optional, overload, Union
 
 from deprecated.sphinx import deprecated
 
@@ -112,47 +112,26 @@ class QueryBuilder:
         """
         ...
 
-    @no_type_check
-    def add_wildcard_query(self, *args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> QueryBuilder:
+    def add_wildcard_query(
+        self, wildcard_query: Union[str, WildcardQuery], case_sensitive: bool = False
+    ) -> QueryBuilder:
         """
         This method is the implementation of `add_wildcard_query`.
 
         Type check is disabled since it executes runtime checks to ensure
         passed-in arguments match the defined signatures.
         """
-        num_param: int = len(args) + len(kwargs)
-        if 1 == num_param:
-            wildcard_query: Union[WildcardQuery, str] = (
-                args[0] if 1 == len(args) else kwargs["wildcard_query"]
-            )
-            if isinstance(wildcard_query, WildcardQuery):
-                self._wildcard_queries.append(wildcard_query)
-            elif isinstance(wildcard_query, str):
-                warnings.warn(
-                    _add_wildcard_query_deprecation_warning_message,
-                    DeprecationWarning,
-                )
-                self._wildcard_queries.append(FullStringWildcardQuery(wildcard_query, False))
-            else:
-                raise TypeError
+        if isinstance(wildcard_query, WildcardQuery):
+            self._wildcard_queries.append(wildcard_query)
             return self
-        if 2 == num_param:
-            wildcard_query: str
-            case_sensitive: bool
-            if 2 == len(args):
-                wildcard_query = args[0]
-                case_sensitive = args[1]
-            else:
-                wildcard_query = args[0] if 1 == len(args) else kwargs["wildcard_query"]
-                case_sensitive = kwargs["case_sensitive"]
-            if not (isinstance(wildcard_query, str) and isinstance(case_sensitive, bool)):
-                raise TypeError
+        elif isinstance(wildcard_query, str):
             warnings.warn(
                 _add_wildcard_query_deprecation_warning_message,
                 DeprecationWarning,
             )
             self._wildcard_queries.append(FullStringWildcardQuery(wildcard_query, case_sensitive))
             return self
+
         raise NotImplementedError
 
     def add_wildcard_queries(self, wildcard_queries: List[WildcardQuery]) -> QueryBuilder:

--- a/clp_ffi_py/wildcard_query.py
+++ b/clp_ffi_py/wildcard_query.py
@@ -1,3 +1,6 @@
+from deprecated.sphinx import deprecated
+
+
 class WildcardQuery:
     """
     This class defines a wildcard query, which includes a wildcard string and a
@@ -12,6 +15,11 @@ class WildcardQuery:
     Other characters which are escaped are treated as normal characters.
     """
 
+    @deprecated(
+        version="0.0.12",
+        reason="`WildcardQuery` should not be used directly."
+        " Please use `SubstringWildcardQuery` and `FullStringWildcardQuery` instead.",
+    )
     def __init__(self, wildcard_query: str, case_sensitive: bool = False):
         """
         Initializes a wildcard query using the given parameters.

--- a/clp_ffi_py/wildcard_query.py
+++ b/clp_ffi_py/wildcard_query.py
@@ -1,10 +1,12 @@
+import warnings
+
 from deprecated.sphinx import deprecated
 
 
 class WildcardQuery:
     """
-    This class defines a wildcard query, which includes a wildcard string and a
-    boolean value to indicate if the match is case-sensitive.
+    This class defines an abstract wildcard query. It includes a wildcard string
+    and a boolean value to indicate if the match is case-sensitive.
 
     A wildcard string may contain the following types of supported wildcards:
 
@@ -17,8 +19,10 @@ class WildcardQuery:
 
     @deprecated(
         version="0.0.12",
-        reason="`WildcardQuery` should not be used directly."
-        " Please use `SubstringWildcardQuery` and `FullStringWildcardQuery` instead.",
+        reason="`clp_ffi_py.wildcard_query.WildcardQuery` is supposed to be an abstract class and"
+        " should not be used directly. To create a wildcard query, please explicit instantiate"
+        " `clp_ffi_py.wildcard_query.SubstringWildcardQuery` or"
+        " `clp_ffi_py.wildcard_query.FullStringWildcardQuery`.",
     )
     def __init__(self, wildcard_query: str, case_sensitive: bool = False):
         """
@@ -35,7 +39,7 @@ class WildcardQuery:
         :return: The string representation of the WildcardQuery object.
         """
         return (
-            f'WildcardQuery(wildcard_query="{self._wildcard_query}",'
+            f'{self.__class__.__name__}(wildcard_query="{self._wildcard_query}",'
             f" case_sensitive={self._case_sensitive})"
         )
 
@@ -52,3 +56,42 @@ class WildcardQuery:
     @property
     def case_sensitive(self) -> bool:
         return self._case_sensitive
+
+
+class SubstringWildcardQuery(WildcardQuery):
+    """
+    This class defines a substring wildcard query.
+
+    It is derived from
+    :class:`~clp_ffi_py.WildcardQuery`, adding both a prefix and a postfix
+    wildcard ("*") to the input wildcard string. This allows the query to match
+    any substring within a log message.
+    """
+
+    def __init__(self, substring_wildcard_query: str, case_sensitive: bool = False):
+        """
+        Initializes a substring wildcard query using the given parameters.
+
+        :param substring_wildcard_query: Wildcard query string.
+        :param case_sensitive: Case sensitive indicator.
+        """
+        substring_wildcard_query = "*" + substring_wildcard_query + "*"
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            super().__init__(substring_wildcard_query, case_sensitive)
+
+
+class FullStringWildcardQuery(WildcardQuery):
+    """
+    This class defines a full string wildcard query.
+
+    It is derived from
+    :class:`~clp_ffi_py.WildcardQuery`, and uses the input wildcard string
+    directly to create the query. This ensures that the query matches only the
+    entire log message.
+    """
+
+    def __init__(self, full_string_wildcard_query: str, case_sensitive: bool = False):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            super().__init__(full_string_wildcard_query, case_sensitive)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ requires-python = ">=3.7"
 dependencies = [
     "Deprecated >= 1.2.14",
     "python-dateutil >= 2.7.0",
-    "types-Deprecated >= 1.2.9",
     "typing-extensions >= 4.1.1",
     "zstandard >= 0.18.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ description = "Python interface to the CLP Core Features through CLP's FFI"
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
+    "Deprecated >= 1.2.14",
     "python-dateutil >= 2.7.0",
+    "types-Deprecated >= 1.2.9",
     "typing-extensions >= 4.1.1",
     "zstandard >= 0.18.0",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,5 +8,6 @@ mypy-extensions>=1.0.0
 packaging>=21.3
 ruff>=0.1.6
 smart_open==6.4.0
+types-Deprecated>=1.2.9
 types-python-dateutil>=2.8
 zstandard>=0.18.0

--- a/src/clp_ffi_py/ir/native/PyQuery.cpp
+++ b/src/clp_ffi_py/ir/native/PyQuery.cpp
@@ -109,7 +109,7 @@ auto serialize_wildcard_queries(std::vector<WildcardQuery> const& wildcard_queri
         PyObjectPtr<PyObject> const is_case_sensitive{get_py_bool(wildcard_query.is_case_sensitive()
         )};
         PyObject* py_wildcard_query{PyObject_CallFunction(
-                PyQuery::get_py_wildcard_query_type(),
+                PyQuery::get_py_full_string_wildcard_query_type(),
                 "OO",
                 wildcard_py_str,
                 is_case_sensitive.get()
@@ -644,6 +644,7 @@ auto PyQuery::init(
 
 PyObjectStaticPtr<PyTypeObject> PyQuery::m_py_type{nullptr};
 PyObjectStaticPtr<PyObject> PyQuery::m_py_wildcard_query_type{nullptr};
+PyObjectStaticPtr<PyObject> PyQuery::m_py_full_string_wildcard_query_type{nullptr};
 
 auto PyQuery::get_py_type() -> PyTypeObject* {
     return m_py_type.get();
@@ -651,6 +652,10 @@ auto PyQuery::get_py_type() -> PyTypeObject* {
 
 auto PyQuery::get_py_wildcard_query_type() -> PyObject* {
     return m_py_wildcard_query_type.get();
+}
+
+auto PyQuery::get_py_full_string_wildcard_query_type() -> PyObject* {
+    return m_py_full_string_wildcard_query_type.get();
 }
 
 auto PyQuery::module_level_init(PyObject* py_module) -> bool {
@@ -669,11 +674,18 @@ auto PyQuery::module_level_init(PyObject* py_module) -> bool {
     if (nullptr == py_query) {
         return false;
     }
-    auto* py_wildcard_query_type = PyObject_GetAttrString(py_query, "WildcardQuery");
+    auto* py_wildcard_query_type{PyObject_GetAttrString(py_query, "WildcardQuery")};
     if (nullptr == py_wildcard_query_type) {
         return false;
     }
     m_py_wildcard_query_type.reset(py_wildcard_query_type);
+    auto* py_full_string_wildcard_query_type{
+            PyObject_GetAttrString(py_query, "FullStringWildcardQuery")
+    };
+    if (nullptr == py_full_string_wildcard_query_type) {
+        return false;
+    }
+    m_py_full_string_wildcard_query_type.reset(py_full_string_wildcard_query_type);
     return true;
 }
 }  // namespace clp_ffi_py::ir::native

--- a/src/clp_ffi_py/ir/native/PyQuery.hpp
+++ b/src/clp_ffi_py/ir/native/PyQuery.hpp
@@ -76,12 +76,19 @@ public:
      */
     [[nodiscard]] static auto get_py_wildcard_query_type() -> PyObject*;
 
+    /**
+     * @return PyObject that represents the Python level class
+     * `FullStringWildcardQuery`.
+     */
+    [[nodiscard]] static auto get_py_full_string_wildcard_query_type() -> PyObject*;
+
 private:
     PyObject_HEAD;
     Query* m_query;
 
     static PyObjectStaticPtr<PyTypeObject> m_py_type;
     static PyObjectStaticPtr<PyObject> m_py_wildcard_query_type;
+    static PyObjectStaticPtr<PyObject> m_py_full_string_wildcard_query_type;
 };
 }  // namespace clp_ffi_py::ir::native
 #endif

--- a/src/clp_ffi_py/ir/native/Query.hpp
+++ b/src/clp_ffi_py/ir/native/Query.hpp
@@ -26,7 +26,7 @@ public:
      */
     WildcardQuery(std::string wildcard_query, bool case_sensitive)
             : m_wildcard_query(std::move(wildcard_query)),
-              m_case_sensitive(case_sensitive){};
+              m_case_sensitive(case_sensitive) {};
 
     [[nodiscard]] auto get_wildcard_query() const -> std::string const& { return m_wildcard_query; }
 

--- a/tests/test_ir/test_query.py
+++ b/tests/test_ir/test_query.py
@@ -7,7 +7,7 @@ from clp_ffi_py.ir import (
     LogEvent,
     Query,
 )
-from clp_ffi_py.wildcard_query import WildcardQuery
+from clp_ffi_py.wildcard_query import FullStringWildcardQuery, SubstringWildcardQuery, WildcardQuery
 
 
 class TestCaseWildcardQuery(TestCLPBase):
@@ -20,20 +20,41 @@ class TestCaseWildcardQuery(TestCLPBase):
         Test the initialization of WildcardQuery object.
         """
         wildcard_string: str
+        expected_wildcard_string: str
         wildcard_query: WildcardQuery
 
         wildcard_string = "Are you the lord of *Pleiades*?"
-        wildcard_query = WildcardQuery(wildcard_string)
-        self._check_wildcard_query(wildcard_query, wildcard_string, False)
+        expected_wildcard_string = wildcard_string
 
-        wildcard_query = WildcardQuery(wildcard_string, True)
-        self._check_wildcard_query(wildcard_query, wildcard_string, True)
+        wildcard_query = FullStringWildcardQuery(wildcard_string)
+        self._check_wildcard_query(wildcard_query, expected_wildcard_string, False)
 
-        wildcard_query = WildcardQuery(wildcard_string, case_sensitive=True)
-        self._check_wildcard_query(wildcard_query, wildcard_string, True)
+        wildcard_query = FullStringWildcardQuery(wildcard_string, True)
+        self._check_wildcard_query(wildcard_query, expected_wildcard_string, True)
 
-        wildcard_query = WildcardQuery(case_sensitive=True, wildcard_query=wildcard_string)
-        self._check_wildcard_query(wildcard_query, wildcard_string, True)
+        wildcard_query = FullStringWildcardQuery(wildcard_string, case_sensitive=True)
+        self._check_wildcard_query(wildcard_query, expected_wildcard_string, True)
+
+        wildcard_query = FullStringWildcardQuery(
+            case_sensitive=True, full_string_wildcard_query=wildcard_string
+        )
+        self._check_wildcard_query(wildcard_query, expected_wildcard_string, True)
+
+        expected_wildcard_string = "*" + wildcard_string + "*"
+
+        wildcard_query = SubstringWildcardQuery(wildcard_string)
+        self._check_wildcard_query(wildcard_query, expected_wildcard_string, False)
+
+        wildcard_query = SubstringWildcardQuery(wildcard_string, True)
+        self._check_wildcard_query(wildcard_query, expected_wildcard_string, True)
+
+        wildcard_query = SubstringWildcardQuery(wildcard_string, case_sensitive=True)
+        self._check_wildcard_query(wildcard_query, expected_wildcard_string, True)
+
+        wildcard_query = SubstringWildcardQuery(
+            case_sensitive=True, substring_wildcard_query=wildcard_string
+        )
+        self._check_wildcard_query(wildcard_query, expected_wildcard_string, True)
 
 
 class TestCaseQuery(TestCLPBase):

--- a/tests/test_ir/test_query_builder.py
+++ b/tests/test_ir/test_query_builder.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import List, Optional
 
 from test_ir.test_utils import TestCLPBase
@@ -225,7 +226,8 @@ class TestCaseQueryBuilder(TestCLPBase):
 
     def test_deprecated(self) -> None:
         """
-        Tests deprecated methods to ensure they are still functionally correct.
+        Tests deprecated methods to ensure they are still functionally correct,
+        and the deprecation warnings are properly captured.
         """
         query_builder: QueryBuilder = QueryBuilder()
         wildcard_query_strings: List[str] = ["aaa", "bbb", "ccc", "ddd"]
@@ -233,12 +235,48 @@ class TestCaseQueryBuilder(TestCLPBase):
         for wildcard_query_str in wildcard_query_strings:
             wildcard_queries.append(FullStringWildcardQuery(wildcard_query_str, False))
 
-        query_builder.add_wildcard_query(wildcard_query_strings[0])
-        query_builder.add_wildcard_query(wildcard_query_strings[1], False)
-        query_builder.add_wildcard_query(wildcard_query_strings[2], case_sensitive=False)
-        query_builder.add_wildcard_query(
-            case_sensitive=False, wildcard_query=wildcard_query_strings[3]
-        )
+        deprecation_warn_captured: bool
+
+        deprecation_warn_captured = False
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            query_builder.add_wildcard_query(wildcard_query_strings[0])
+            self.assertNotEqual(None, caught_warnings)
+            for warning in caught_warnings:
+                if issubclass(warning.category, DeprecationWarning):
+                    deprecation_warn_captured = True
+                    break
+            self.assertTrue(deprecation_warn_captured)
+
+        deprecation_warn_captured = False
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            query_builder.add_wildcard_query(wildcard_query_strings[1], False)
+            self.assertNotEqual(None, caught_warnings)
+            for warning in caught_warnings:
+                if issubclass(warning.category, DeprecationWarning):
+                    deprecation_warn_captured = True
+                    break
+            self.assertTrue(deprecation_warn_captured)
+
+        deprecation_warn_captured = False
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            query_builder.add_wildcard_query(wildcard_query_strings[2], case_sensitive=False)
+            self.assertNotEqual(None, caught_warnings)
+            for warning in caught_warnings:
+                if issubclass(warning.category, DeprecationWarning):
+                    deprecation_warn_captured = True
+                    break
+            self.assertTrue(deprecation_warn_captured)
+
+        deprecation_warn_captured = False
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            query_builder.add_wildcard_query(
+                case_sensitive=False, wildcard_query=wildcard_query_strings[3]
+            )
+            for warning in caught_warnings:
+                if issubclass(warning.category, DeprecationWarning):
+                    deprecation_warn_captured = True
+                    break
+            self.assertTrue(deprecation_warn_captured)
 
         self._check_query(
             query_builder.build(),


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
As discussed in PR #27, users usually want the query to be automatically surrounded with wildcard `*` to match a substring. This PR implements such a query in a way we discussed and agreed on in PR #27. Essentially, this PR contains the following changes:
- Redesign `WildcardQuery` classes. `WildcardQuery` is now marked as deprecated. Instead, users should use its derived class `SubstringWildcardQuery` and `FullStringWildcardQuery` to define a wildcard query. When using `SubstringWildcardQuery`, `*` prefix and postfix will be automatically added to match a substring.
- Redesign `QueryBuilder` to change the method's signature of `add_wildcard_query`. It's taking a `WildcardQuery` class instead of a string and a boolean argument. The old signature can still be called but it is marked as deprecated.

We can support substring matches without breaking existing user code with the above implementations. In the future, we should also do the following cleanup:
- Formally remove the old signature of `add_wildcard_query`
- Make `WildcardQuery` as an abstract base class
- Close PR #27

# Validation performed
<!-- What tests and validation you performed on the change -->
- All unit tests passed
- Add unit tests to cover deprecated functions
- CI passed, successfully built and tested across all the supported platforms and Python versions

