### PR TITLE
gh-actions: Run linting workflow daily to validate latest linting tool versions.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -29,6 +29,9 @@ on:
       - "setup.py"
       - "src/**"
       - "tests/**"
+  schedule:
+    # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
+    - cron: "15 0 * * *"
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR schedules the workflow to run every midnight in UTC (with a 15-minute delay added to avoid GitHub high workload).
This PR is mirroring this CLP core PR: https://github.com/y-scope/clp/pull/385

# Validation performed
<!-- What tests and validation you performed on the change -->
Ensure the workflow successfully started with the updated config.
Since the same setting is already used in CLP core, I didn't validate the actual scheduling.

