### PR TITLE
gh-actions: Change linting workflow schedule from daily to weekly.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -30,7 +30,7 @@ on:
       - "src/**"
       - "tests/**"
   schedule:
-    # Run at midnight UTC every Tuesday with 15 minutes delay added to avoid high load periods
+    # Run every Tuesday at 00:15 UTC (the 15 is to avoid periods of high load)
     - cron: "15 0 * * 2"
 
 concurrency:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -30,8 +30,8 @@ on:
       - "src/**"
       - "tests/**"
   schedule:
-    # Run at midnight UTC every day with 15 minutes delay added to avoid high load periods
-    - cron: "15 0 * * *"
+    # Run at midnight UTC every Tuesday with 15 minutes delay added to avoid high load periods
+    - cron: "15 0 * * 2"
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      
+
       - run: |
           pip install --upgrade pip
           pip install -r requirements-dev.txt


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The current scheduled linting workflow runs too frequently and it frequently fails due to intensive workloads in GitHub. This failure could even propagate to the forked repos, which will bring confusion to the developers. As a solution, we decide to switch to weekly execution. Tuesday is chosen to avoid potential high GitHub traffic on Monday or Sunday.
Reference: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule

# Validation performed
<!-- What tests and validation you performed on the change -->
Ensure the current workflow passes.

