### PR TITLE
Temporarily lock clang-format to v18.x to resolve lint failures; Update to latest commit of CLP core (fixes #70).

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 black>=24.4.2
 build>=0.8.0
 cibuildwheel>=2.16.2
+# Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
 clang-format~=18.1
 docformatter>=1.7.5
 mypy>=1.10.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 black>=24.4.2
 build>=0.8.0
 cibuildwheel>=2.16.2
-clang-format>=18.1.5
+clang-format~=18.1
 docformatter>=1.7.5
 mypy>=1.10.0
 mypy-extensions>=1.0.0


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR:
- Temporary locking clang-format to version 18 to work around (#71)
- Update to the latest commit of CLP core to apply the [fix](https://github.com/y-scope/clp/pull/561) (#70)

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure local build worked.
- Ensure workflow all passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version specification for the `clang-format` dependency to ensure compatibility.
	- Updated the commit hash for a subproject, reflecting its latest state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->