### PR TITLE
Add backward compatibility for the deprecated APIs renamed in #68.

### DIFF
--- a/clp_ffi_py/ir/__init__.py
+++ b/clp_ffi_py/ir/__init__.py
@@ -1,7 +1,7 @@
 from clp_ffi_py.ir.native import *
+from clp_ffi_py.ir.native_deprecated import *
 from clp_ffi_py.ir.query_builder import *
 from clp_ffi_py.ir.readers import *
-from clp_ffi_py.ir.native_deprecated import *
 
 from typing import List
 

--- a/clp_ffi_py/ir/__init__.py
+++ b/clp_ffi_py/ir/__init__.py
@@ -1,12 +1,16 @@
 from clp_ffi_py.ir.native import *
 from clp_ffi_py.ir.query_builder import *
 from clp_ffi_py.ir.readers import *
+from clp_ffi_py.ir.native_deprecated import *
 
 from typing import List
 
 __all__: List[str] = [
+    "Decoder",  # native_deprecated
+    "DecoderBuffer",  # native_deprecated
     "DeserializerBuffer",  # native
     "FourByteDeserializer",  # native
+    "FourByteEncoder",  # native_deprecated
     "FourByteSerializer",  # native
     "IncompleteStreamError",  # native
     "LogEvent",  # native

--- a/clp_ffi_py/ir/native.pyi
+++ b/clp_ffi_py/ir/native.pyi
@@ -77,7 +77,7 @@ class FourByteDeserializer:
     def deserialize_preamble(decoder_buffer: DeserializerBuffer) -> Metadata: ...
     @staticmethod
     def deserialize_next_log_event(
-        decoder_buffer: DeserializerBuffer,
+        deserializer_buffer: DeserializerBuffer,
         query: Optional[Query] = None,
         allow_incomplete_stream: bool = False,
     ) -> Optional[LogEvent]: ...

--- a/clp_ffi_py/ir/native_deprecated.py
+++ b/clp_ffi_py/ir/native_deprecated.py
@@ -1,0 +1,138 @@
+from typing import IO, Optional
+
+from deprecated.sphinx import deprecated
+
+from clp_ffi_py.ir.native import (
+    DeserializerBuffer,
+    FourByteDeserializer,
+    FourByteSerializer,
+    LogEvent,
+    Metadata,
+    Query,
+)
+
+
+@deprecated(
+    version="0.0.13",
+    reason=":class:`FourByteEncoder` is deprecated; use"
+    " :class:`~clp_ffi_py.ir.native.FourByteSerializer` instead.",
+)
+class FourByteEncoder:
+    @staticmethod
+    def encode_preamble(ref_timestamp: int, timestamp_format: str, timezone: str) -> bytearray:
+        """
+        This method is deprecated.
+
+        Please check
+        :meth:`~clp_ffi_py.ir.native.FourByteSerializer.serialize_preamble`.
+        """
+        return FourByteSerializer.serialize_preamble(ref_timestamp, timestamp_format, timezone)
+
+    @staticmethod
+    def encode_message_and_timestamp_delta(timestamp_delta: int, msg: bytes) -> bytearray:
+        """
+        This method is deprecated.
+
+        Please check
+        :meth:`~clp_ffi_py.ir.native.FourByteSerializer.serialize_message_and_timestamp_delta`.
+        """
+        return FourByteSerializer.serialize_message_and_timestamp_delta(
+            timestamp_delta,
+            msg,
+        )
+
+    @staticmethod
+    def encode_message(msg: bytes) -> bytearray:
+        """
+        This method is deprecated.
+
+        Please check
+        :meth:`~clp_ffi_py.ir.native.FourByteSerializer.serialize_message`.
+        """
+        return FourByteSerializer.serialize_message(msg)
+
+    @staticmethod
+    def encode_timestamp_delta(timestamp_delta: int) -> bytearray:
+        """
+        This method is deprecated.
+
+        Please check
+        :meth:`~clp_ffi_py.ir.native.FourByteSerializer.serialize_timestamp_delta`.
+        """
+        return FourByteSerializer.serialize_timestamp_delta(timestamp_delta)
+
+    @staticmethod
+    def encode_end_of_ir() -> bytearray:
+        """
+        This method is deprecated.
+
+        Please check
+        :meth:`~clp_ffi_py.ir.native.FourByteSerializer.serialize_end_of_ir`.
+        """
+        return FourByteSerializer.serialize_end_of_ir()
+
+
+@deprecated(
+    version="0.0.13",
+    reason=":class:`DecoderBuffer` is deprecated; use"
+    " :class:`~clp_ffi_py.ir.native.DeserializerBuffer` instead.",
+)
+class DecoderBuffer:
+    def __init__(self, input_stream: IO[bytes], initial_buffer_capacity: int = 4096):
+        self._deserializer_buffer = DeserializerBuffer(
+            input_stream=input_stream, initial_buffer_capacity=initial_buffer_capacity
+        )
+
+    def get_num_decoded_log_messages(self) -> int:
+        """
+        Please check
+        :meth:`~clp_ffi_py.ir.native.DeserializerBuffer.get_num_deserialized_log_messages`.
+        """
+        return self._deserializer_buffer.get_num_deserialized_log_messages()
+
+    def _test_streaming(self, seed: int) -> bytearray:
+        """
+        Please check :meth:`~clp_ffi_py.ir.native.DeserializerBuffer._test_streaming`.
+        """
+        return self._deserializer_buffer._test_streaming(seed)
+
+
+@deprecated(
+    version="0.0.13",
+    reason=":class:`Decoder` is deprecated; use"
+    " :class:`~clp_ffi_py.ir.native.FourByteDeserializer` with"
+    " :class:`~clp_ffi_py.ir.native.DeserializerBuffer` instead.",
+)
+class Decoder:
+    @staticmethod
+    def decode_preamble(decoder_buffer: DecoderBuffer) -> Metadata:
+        """
+        This method is deprecated.
+
+        Please check
+        :meth:`~clp_ffi_py.ir.native.FourByteDeserializer.deserialize_preamble`.
+        """
+        return FourByteDeserializer.deserialize_preamble(decoder_buffer._deserializer_buffer)
+
+    @staticmethod
+    def decode_next_log_event(
+        decoder_buffer: DecoderBuffer,
+        query: Optional[Query] = None,
+        allow_incomplete_stream: bool = False,
+    ) -> Optional[LogEvent]:
+        """
+        This method is deprecated.
+
+        Please check
+        :meth:`~clp_ffi_py.ir.native.FourByteDeserializer.deserialize_next_log_event`.
+        """
+        return FourByteDeserializer.deserialize_next_log_event(
+            deserializer_buffer=decoder_buffer._deserializer_buffer,
+            query=query,
+            allow_incomplete_stream=allow_incomplete_stream,
+        )
+
+
+# Delete `__new__` so that it will be ignored by Sphinx.
+del Decoder.__new__
+del FourByteEncoder.__new__

--- a/clp_ffi_py/ir/native_deprecated.py
+++ b/clp_ffi_py/ir/native_deprecated.py
@@ -14,16 +14,14 @@ from clp_ffi_py.ir.native import (
 
 @deprecated(
     version="0.0.13",
-    reason=":class:`FourByteEncoder` is deprecated; use"
-    " :class:`~clp_ffi_py.ir.native.FourByteSerializer` instead.",
+    reason=":class:`FourByteEncoder` is deprecated and has been renamed to"
+    " :class:`~clp_ffi_py.ir.native.FourByteSerializer`.",
 )
 class FourByteEncoder:
     @staticmethod
     def encode_preamble(ref_timestamp: int, timestamp_format: str, timezone: str) -> bytearray:
         """
-        This method is deprecated.
-
-        Please check
+        This method is deprecated and has been renamed to
         :meth:`~clp_ffi_py.ir.native.FourByteSerializer.serialize_preamble`.
         """
         return FourByteSerializer.serialize_preamble(ref_timestamp, timestamp_format, timezone)
@@ -31,9 +29,7 @@ class FourByteEncoder:
     @staticmethod
     def encode_message_and_timestamp_delta(timestamp_delta: int, msg: bytes) -> bytearray:
         """
-        This method is deprecated.
-
-        Please check
+        This method is deprecated and has been renamed to
         :meth:`~clp_ffi_py.ir.native.FourByteSerializer.serialize_message_and_timestamp_delta`.
         """
         return FourByteSerializer.serialize_message_and_timestamp_delta(
@@ -44,9 +40,7 @@ class FourByteEncoder:
     @staticmethod
     def encode_message(msg: bytes) -> bytearray:
         """
-        This method is deprecated.
-
-        Please check
+        This method is deprecated and has been renamed to
         :meth:`~clp_ffi_py.ir.native.FourByteSerializer.serialize_message`.
         """
         return FourByteSerializer.serialize_message(msg)
@@ -54,9 +48,7 @@ class FourByteEncoder:
     @staticmethod
     def encode_timestamp_delta(timestamp_delta: int) -> bytearray:
         """
-        This method is deprecated.
-
-        Please check
+        This method is deprecated and has been renamed to
         :meth:`~clp_ffi_py.ir.native.FourByteSerializer.serialize_timestamp_delta`.
         """
         return FourByteSerializer.serialize_timestamp_delta(timestamp_delta)
@@ -64,9 +56,7 @@ class FourByteEncoder:
     @staticmethod
     def encode_end_of_ir() -> bytearray:
         """
-        This method is deprecated.
-
-        Please check
+        This method is deprecated and has been renamed to
         :meth:`~clp_ffi_py.ir.native.FourByteSerializer.serialize_end_of_ir`.
         """
         return FourByteSerializer.serialize_end_of_ir()
@@ -74,8 +64,8 @@ class FourByteEncoder:
 
 @deprecated(
     version="0.0.13",
-    reason=":class:`DecoderBuffer` is deprecated; use"
-    " :class:`~clp_ffi_py.ir.native.DeserializerBuffer` instead.",
+    reason=":class:`DecoderBuffer` is deprecated and has been renamed to"
+    " :class:`~clp_ffi_py.ir.native.DeserializerBuffer`.",
 )
 class DecoderBuffer:
     def __init__(self, input_stream: IO[bytes], initial_buffer_capacity: int = 4096):
@@ -85,31 +75,27 @@ class DecoderBuffer:
 
     def get_num_decoded_log_messages(self) -> int:
         """
-        Please check
-        :meth:`~clp_ffi_py.ir.native.DeserializerBuffer.get_num_deserialized_log_messages`.
+        See :meth:`~clp_ffi_py.ir.native.DeserializerBuffer.get_num_deserialized_log_messages`.
         """
         return self._deserializer_buffer.get_num_deserialized_log_messages()
 
     def _test_streaming(self, seed: int) -> bytearray:
         """
-        Please check :meth:`~clp_ffi_py.ir.native.DeserializerBuffer._test_streaming`.
+        See :meth:`~clp_ffi_py.ir.native.DeserializerBuffer._test_streaming`.
         """
         return self._deserializer_buffer._test_streaming(seed)
 
 
 @deprecated(
     version="0.0.13",
-    reason=":class:`Decoder` is deprecated; use"
-    " :class:`~clp_ffi_py.ir.native.FourByteDeserializer` with"
-    " :class:`~clp_ffi_py.ir.native.DeserializerBuffer` instead.",
+    reason=":class:`Decoder` is deprecated and has been renamed to"
+    " :class:`~clp_ffi_py.ir.native.FourByteDeserializer`.",
 )
 class Decoder:
     @staticmethod
     def decode_preamble(decoder_buffer: DecoderBuffer) -> Metadata:
         """
-        This method is deprecated.
-
-        Please check
+        This method is deprecated and has been renamed to
         :meth:`~clp_ffi_py.ir.native.FourByteDeserializer.deserialize_preamble`.
         """
         return FourByteDeserializer.deserialize_preamble(decoder_buffer._deserializer_buffer)
@@ -121,9 +107,7 @@ class Decoder:
         allow_incomplete_stream: bool = False,
     ) -> Optional[LogEvent]:
         """
-        This method is deprecated.
-
-        Please check
+        This method is deprecated and has been renamed to
         :meth:`~clp_ffi_py.ir.native.FourByteDeserializer.deserialize_next_log_event`.
         """
         return FourByteDeserializer.deserialize_next_log_event(

--- a/clp_ffi_py/ir/native_deprecated.py
+++ b/clp_ffi_py/ir/native_deprecated.py
@@ -75,7 +75,8 @@ class DecoderBuffer:
 
     def get_num_decoded_log_messages(self) -> int:
         """
-        See :meth:`~clp_ffi_py.ir.native.DeserializerBuffer.get_num_deserialized_log_messages`.
+        This method is deprecated and has been renamed to
+        :meth:`~clp_ffi_py.ir.native.DeserializerBuffer.get_num_deserialized_log_messages`.
         """
         return self._deserializer_buffer.get_num_deserialized_log_messages()
 

--- a/clp_ffi_py/ir/readers.py
+++ b/clp_ffi_py/ir/readers.py
@@ -23,7 +23,7 @@ class ClpIrStreamReader(Iterator[LogEvent]):
         an error. Instead, encountering such a stream is seen as reaching its end without raising
         any exceptions.
     :param decoder_buffer_size: Deprecated in 0.0.13. The purpose of this argument is to provide
-        backward compatibility. If not None, `deserializer_buffer_size`'s value will be ignored.
+        backward compatibility. It overwrites `deserializer_buffer_size`'s value if not None.
     """
 
     DEFAULT_DESERIALIZER_BUFFER_SIZE: int = 65536

--- a/clp_ffi_py/ir/readers.py
+++ b/clp_ffi_py/ir/readers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from sys import stderr
 from types import TracebackType
 from typing import Generator, IO, Iterator, Optional, Type, Union
+from warnings import warn
 
 from zstandard import ZstdDecompressionReader, ZstdDecompressor
 
@@ -21,9 +22,12 @@ class ClpIrStreamReader(Iterator[LogEvent]):
     :param allow_incomplete_stream: If set to `True`, an incomplete CLP IR stream is not treated as
         an error. Instead, encountering such a stream is seen as reaching its end without raising
         any exceptions.
+    :param decoder_buffer_size: Deprecated in 0.0.13. The purpose of this argument is to provide
+        backward compatibility. If not None, `deserializer_buffer_size`'s value will be ignored.
     """
 
     DEFAULT_DESERIALIZER_BUFFER_SIZE: int = 65536
+    DEFAULT_DECODER_BUFFER_SIZE: int = DEFAULT_DESERIALIZER_BUFFER_SIZE
 
     def __init__(
         self,
@@ -31,7 +35,17 @@ class ClpIrStreamReader(Iterator[LogEvent]):
         deserializer_buffer_size: int = DEFAULT_DESERIALIZER_BUFFER_SIZE,
         enable_compression: bool = True,
         allow_incomplete_stream: bool = False,
+        decoder_buffer_size: Optional[int] = None,
     ):
+        if decoder_buffer_size is not None:
+            deserializer_buffer_size = decoder_buffer_size
+            warn(
+                "Argument `decoder_buffer_size` has been renamed to `deserializer_buffer_size` "
+                "since 0.0.13",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+
         self.__istream: Union[IO[bytes], ZstdDecompressionReader]
         if enable_compression:
             dctx: ZstdDecompressor = ZstdDecompressor()
@@ -138,7 +152,16 @@ class ClpIrFileReader(ClpIrStreamReader):
         deserializer_buffer_size: int = ClpIrStreamReader.DEFAULT_DESERIALIZER_BUFFER_SIZE,
         enable_compression: bool = True,
         allow_incomplete_stream: bool = False,
+        decoder_buffer_size: Optional[int] = None,
     ):
+        if decoder_buffer_size is not None:
+            deserializer_buffer_size = decoder_buffer_size
+            warn(
+                "Argument `decoder_buffer_size` has been renamed to `deserializer_buffer_size` "
+                "since 0.0.13",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
         self._path: Path = fpath
         super().__init__(
             open(fpath, "rb"),

--- a/clp_ffi_py/ir/readers.py
+++ b/clp_ffi_py/ir/readers.py
@@ -22,8 +22,9 @@ class ClpIrStreamReader(Iterator[LogEvent]):
     :param allow_incomplete_stream: If set to `True`, an incomplete CLP IR stream is not treated as
         an error. Instead, encountering such a stream is seen as reaching its end without raising
         any exceptions.
-    :param decoder_buffer_size: Deprecated in 0.0.13. The purpose of this argument is to provide
-        backward compatibility. It overwrites `deserializer_buffer_size`'s value if not None.
+    :param decoder_buffer_size: Deprecated since 0.0.13. Use `deserializer_buffer_size` instead.
+        This argument is provided for backward compatibility and if set, will overwrite
+        `deserializer_buffer_size`'s value.
     """
 
     DEFAULT_DESERIALIZER_BUFFER_SIZE: int = 65536
@@ -40,8 +41,8 @@ class ClpIrStreamReader(Iterator[LogEvent]):
         if decoder_buffer_size is not None:
             deserializer_buffer_size = decoder_buffer_size
             warn(
-                "Argument `decoder_buffer_size` has been renamed to `deserializer_buffer_size` "
-                "since 0.0.13",
+                "Argument `decoder_buffer_size` has been renamed to `deserializer_buffer_size`"
+                " since 0.0.13",
                 category=DeprecationWarning,
                 stacklevel=2,
             )
@@ -157,8 +158,8 @@ class ClpIrFileReader(ClpIrStreamReader):
         if decoder_buffer_size is not None:
             deserializer_buffer_size = decoder_buffer_size
             warn(
-                "Argument `decoder_buffer_size` has been renamed to `deserializer_buffer_size` "
-                "since 0.0.13",
+                "Argument `decoder_buffer_size` has been renamed to `deserializer_buffer_size`"
+                " since 0.0.13",
                 category=DeprecationWarning,
                 stacklevel=2,
             )

--- a/docs/src/api/clp_ffi_py.ir.native_deprecated.rst
+++ b/docs/src/api/clp_ffi_py.ir.native_deprecated.rst
@@ -1,0 +1,12 @@
+clp\_ffi\_py.ir.native\_deprecated module
+=========================================
+
+.. automodule:: clp_ffi_py.ir.native_deprecated
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :exclude-members: DecoderBuffer
+
+    .. autoclass:: DecoderBuffer
+        :members:
+        :exclude-members: __new__

--- a/docs/src/api/clp_ffi_py.ir.rst
+++ b/docs/src/api/clp_ffi_py.ir.rst
@@ -8,6 +8,7 @@ Submodules
    :maxdepth: 4
 
    clp_ffi_py.ir.native
+   clp_ffi_py.ir.native_deprecated
    clp_ffi_py.ir.query_builder
    clp_ffi_py.ir.readers
 

--- a/tests/test_ir/__init__.py
+++ b/tests/test_ir/__init__.py
@@ -1,8 +1,11 @@
 import unittest
 from typing import Iterable, Optional, Union
 
+from test_ir.test_decoder import *  # noqa
+from test_ir.test_decoder_buffer import *  # noqa
 from test_ir.test_deserializer import *  # noqa
 from test_ir.test_deserializer_buffer import *  # noqa
+from test_ir.test_encoder import *  # noqa
 from test_ir.test_log_event import *  # noqa
 from test_ir.test_metadata import *  # noqa
 from test_ir.test_query import *  # noqa

--- a/tests/test_ir/test_decoder.py
+++ b/tests/test_ir/test_decoder.py
@@ -1,0 +1,422 @@
+import random
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from smart_open import open  # type: ignore
+from test_ir.test_utils import get_current_timestamp, LogGenerator, TestCLPBase
+
+from clp_ffi_py.ir import (
+    Decoder,
+    DecoderBuffer,
+    FourByteEncoder,
+    LogEvent,
+    Metadata,
+    Query,
+)
+from clp_ffi_py.wildcard_query import WildcardQuery
+
+LOG_DIR: Path = Path("unittest-logs")
+
+
+class TestCaseDecoderBase(TestCLPBase):
+    """
+    Class for testing clp_ffi_py.ir.Decoder.
+    """
+
+    encoded_log_path_prefix: str
+    encoded_log_path_postfix: str
+    num_test_iterations: int
+    enable_compression: bool
+    has_query: bool
+
+    # override
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not LOG_DIR.exists():
+            LOG_DIR.mkdir(parents=True, exist_ok=True)
+        assert LOG_DIR.is_dir()
+
+    # override
+    def setUp(self) -> None:
+        self.encoded_log_path_prefix: str = f"{self.id()}"
+        self.encoded_log_path_postfix: str = "clp.zst" if self.enable_compression else "clp"
+        for i in range(self.num_test_iterations):
+            log_path = self._get_log_path(i)
+            if log_path.exists():
+                log_path.unlink()
+
+    def _get_log_path(self, iter: int) -> Path:
+        log_path: Path = LOG_DIR / Path(
+            f"{self.encoded_log_path_prefix}.{iter}.{self.encoded_log_path_postfix}"
+        )
+        return log_path
+
+    def _encode_log_stream(
+        self, log_path: Path, metadata: Metadata, log_events: List[LogEvent]
+    ) -> None:
+        """
+        Encodes the log stream into the given path.
+
+        :param log_path: Path on the local file system to write the stream.
+        :param metadata: Metadata of the log stream.
+        :param log_events: A list of log events to encode.
+        """
+        with open(str(log_path), "wb") as ostream:
+            ref_timestamp: int = metadata.get_ref_timestamp()
+            ostream.write(
+                FourByteEncoder.encode_preamble(
+                    ref_timestamp, metadata.get_timestamp_format(), metadata.get_timezone_id()
+                )
+            )
+            for log_event in log_events:
+                curr_ts: int = log_event.get_timestamp()
+                delta: int = curr_ts - ref_timestamp
+                ref_timestamp = curr_ts
+                log_message: str = log_event.get_log_message()
+                ostream.write(
+                    FourByteEncoder.encode_message_and_timestamp_delta(delta, log_message.encode())
+                )
+            ostream.write(FourByteEncoder.encode_end_of_ir())
+
+    def _encode_random_log_stream(
+        self, log_path: Path, num_log_events_to_generate: int, seed: int
+    ) -> Tuple[Metadata, List[LogEvent]]:
+        """
+        Writes a randomly generated log stream into the local path `log_path`.
+
+        :param log_path: Path on the local file system to write the stream.
+        :param num_log_events_to_generate: Number of log events to generate.
+        :param seed: Random seed used to generate the log stream.
+        :return: A tuple containing the generated log events and the metadata.
+        """
+        metadata: Metadata
+        log_events: List[LogEvent]
+        metadata, log_events = LogGenerator.generate_random_logs(num_log_events_to_generate)
+        try:
+            self._encode_log_stream(log_path, metadata, log_events)
+        except Exception as e:
+            self.assertTrue(
+                False, f"Failed to encode random log stream generated using seed {seed}: {e}"
+            )
+        return metadata, log_events
+
+    def _generate_random_query(
+        self, ref_log_events: List[LogEvent]
+    ) -> Tuple[Query, List[LogEvent]]:
+        """
+        Generates a random query and return all the log events in the given `log_events` that
+        matches this random query.
+
+        The derived class might overwrite this method to generate a random query
+        using customized algorithm. By default, this function returns an empty
+        query and `ref_log_events`.
+        :param log_events: reference log events.
+        :return: A tuple that contains the randomly generated query, and a list
+        of log events filtered from `ref_log_events` by the query.
+        """
+        return Query(), ref_log_events
+
+    def _decode_log_stream(
+        self, log_path: Path, query: Optional[Query]
+    ) -> Tuple[Metadata, List[LogEvent]]:
+        """
+        Decodes the log stream specified by `log_path`, using decoding methods provided in
+        clp_ffi_py.ir.Decoder.
+
+        :param log_path: The path to the log stream.
+        :param query: Optional search query.
+        :return: A tuple that contains the decoded metadata and log events returned from decoding
+            methods.
+        """
+        with open(str(log_path), "rb") as istream:
+            decoder_buffer: DecoderBuffer = DecoderBuffer(istream)
+            metadata: Metadata = Decoder.decode_preamble(decoder_buffer)
+            log_events: List[LogEvent] = []
+            while True:
+                log_event: Optional[LogEvent] = Decoder.decode_next_log_event(decoder_buffer, query)
+                if None is log_event:
+                    break
+                log_events.append(log_event)
+        return metadata, log_events
+
+    def _validate_decoded_logs(
+        self,
+        ref_metadata: Metadata,
+        ref_log_events: List[LogEvent],
+        decoded_metadata: Metadata,
+        decoded_log_events: List[LogEvent],
+        log_path: Path,
+        seed: int,
+    ) -> None:
+        """
+        Validates decoded logs from the IR stream specified by `log_path`.
+
+        :param ref_metadata: Reference metadata.
+        :param ref_log_events: A list of reference log events sequence (order sensitive).
+        :param decoded_metadata: Metadata decoded from the IR stream.
+        :param decoded_log_events: A list of log events decoded from the IR stream in sequence.
+        :param log_path: Local path of the IR stream.
+        :param seed: Random seed used to generate the log events sequence.
+        """
+        test_info: str = f"Seed: {seed}, Log Path: {log_path}"
+        self._check_metadata(
+            decoded_metadata,
+            ref_metadata.get_ref_timestamp(),
+            ref_metadata.get_timestamp_format(),
+            ref_metadata.get_timezone_id(),
+            test_info,
+        )
+
+        ref_num_log_events: int = len(ref_log_events)
+        decoded_num_log_events: int = len(decoded_log_events)
+        self.assertEqual(
+            ref_num_log_events,
+            decoded_num_log_events,
+            "Number of log events decoded does not match.\n" + test_info,
+        )
+        for ref_log_event, decoded_log_event in zip(ref_log_events, decoded_log_events):
+            self._check_log_event(
+                decoded_log_event,
+                ref_log_event.get_log_message(),
+                ref_log_event.get_timestamp(),
+                ref_log_event.get_index(),
+                test_info,
+            )
+
+    def test_decoder_with_random_logs(self) -> None:
+        """
+        Tests encoding/decoding methods.
+
+        Check the TestCase class doc string for more details.
+        """
+        for i in range(self.num_test_iterations):
+            seed: int = get_current_timestamp()
+            random.seed(seed)
+            num_log_events: int = 100 * (i + 1)
+            log_path: Path = self._get_log_path(i)
+
+            ref_metadata: Metadata
+            ref_log_events: List[LogEvent]
+            ref_metadata, ref_log_events = self._encode_random_log_stream(
+                log_path, num_log_events, seed
+            )
+
+            query: Optional[Query] = None
+            if self.has_query:
+                query, ref_log_events = self._generate_random_query(ref_log_events)
+
+            metadata: Metadata
+            log_events: List[LogEvent]
+            try:
+                metadata, log_events = self._decode_log_stream(log_path, query)
+            except Exception as e:
+                self.assertTrue(
+                    False, f"Failed to decode random log stream generated using seed {seed}: {e}"
+                )
+
+            self._validate_decoded_logs(
+                ref_metadata, ref_log_events, metadata, log_events, log_path, seed
+            )
+
+
+class TestCaseDecoderDecompress(TestCaseDecoderBase):
+    """
+    Tests encoding/decoding methods against uncompressed IR stream.
+    """
+
+    # override
+    def setUp(self) -> None:
+        self.enable_compression = False
+        self.has_query = False
+        self.num_test_iterations = 10
+        super().setUp()
+
+
+class TestCaseDecoderDecompressZstd(TestCaseDecoderBase):
+    """
+    Tests encoding/decoding methods against zstd compressed IR stream.
+    """
+
+    # override
+    def setUp(self) -> None:
+        self.enable_compression = True
+        self.has_query = False
+        self.num_test_iterations = 10
+        super().setUp()
+
+
+class TestCaseDecoderDecompressDefaultQuery(TestCaseDecoderBase):
+    """
+    Tests encoding/decoding methods against uncompressed IR stream with the default empty query.
+    """
+
+    # override
+    def setUp(self) -> None:
+        self.enable_compression = False
+        self.has_query = True
+        self.num_test_iterations = 1
+        super().setUp()
+
+
+class TestCaseDecoderDecompressZstdDefaultQuery(TestCaseDecoderBase):
+    """
+    Tests encoding/decoding methods against zstd compressed IR stream with the default empty query.
+    """
+
+    # override
+    def setUp(self) -> None:
+        self.enable_compression = True
+        self.has_query = True
+        self.num_test_iterations = 1
+        super().setUp()
+
+
+class TestCaseDecoderTimeRangeQueryBase(TestCaseDecoderBase):
+    # override
+    def _generate_random_query(
+        self, ref_log_events: List[LogEvent]
+    ) -> Tuple[Query, List[LogEvent]]:
+        self.assertGreater(len(ref_log_events), 0, "The reference log event list is empty.")
+        ts_min: int = ref_log_events[0].get_timestamp()
+        ts_max: int = ref_log_events[-1].get_timestamp()
+        search_time_lower_bound: int = random.randint(ts_min, ts_max)
+        search_time_upper_bound: int = random.randint(search_time_lower_bound, ts_max)
+        query: Query = Query(
+            search_time_lower_bound=search_time_lower_bound,
+            search_time_upper_bound=search_time_upper_bound,
+            search_time_termination_margin=0,
+        )
+        matched_log_events: List[LogEvent] = []
+        for log_event in ref_log_events:
+            if not log_event.match_query(query):
+                continue
+            matched_log_events.append(log_event)
+        return query, matched_log_events
+
+
+class TestCaseDecoderTimeRangeQuery(TestCaseDecoderTimeRangeQueryBase):
+    """
+    Tests encoding/decoding methods against uncompressed IR stream with the query that specifies a
+    search timestamp.
+    """
+
+    # override
+    def setUp(self) -> None:
+        self.enable_compression = False
+        self.has_query = True
+        self.num_test_iterations = 10
+        super().setUp()
+
+
+class TestCaseDecoderTimeRangeQueryZstd(TestCaseDecoderTimeRangeQueryBase):
+    """
+    Tests encoding/decoding methods against zstd compressed IR stream with the query that specifies
+    a search timestamp.
+    """
+
+    # override
+    def setUp(self) -> None:
+        self.enable_compression = True
+        self.has_query = True
+        self.num_test_iterations = 10
+        super().setUp()
+
+
+class TestCaseDecoderWildcardQueryBase(TestCaseDecoderBase):
+    # override
+    def _generate_random_query(
+        self, ref_log_events: List[LogEvent]
+    ) -> Tuple[Query, List[LogEvent]]:
+        wildcard_queries: List[WildcardQuery] = (
+            LogGenerator.generate_random_log_type_wildcard_queries(3)
+        )
+        query: Query = Query(wildcard_queries=wildcard_queries)
+        matched_log_events: List[LogEvent] = []
+        for log_event in ref_log_events:
+            if not log_event.match_query(query):
+                continue
+            matched_log_events.append(log_event)
+        return query, matched_log_events
+
+
+class TestCaseDecoderWildcardQuery(TestCaseDecoderWildcardQueryBase):
+    """
+    Tests encoding/decoding methods against uncompressed IR stream with the query that specifies
+    wildcard queries.
+    """
+
+    # override
+    def setUp(self) -> None:
+        self.enable_compression = False
+        self.has_query = True
+        self.num_test_iterations = 10
+        super().setUp()
+
+
+class TestCaseDecoderWildcardQueryZstd(TestCaseDecoderWildcardQueryBase):
+    """
+    Tests encoding/decoding methods against zstd compressed IR stream with the query that specifies
+    a wildcard queries.
+    """
+
+    # override
+    def setUp(self) -> None:
+        self.enable_compression = True
+        self.has_query = True
+        self.num_test_iterations = 10
+        super().setUp()
+
+
+class TestCaseDecoderTimeRangeWildcardQueryBase(TestCaseDecoderBase):
+    # override
+    def _generate_random_query(
+        self, ref_log_events: List[LogEvent]
+    ) -> Tuple[Query, List[LogEvent]]:
+        self.assertGreater(len(ref_log_events), 0, "The reference log event list is empty.")
+        ts_min: int = ref_log_events[0].get_timestamp()
+        ts_max: int = ref_log_events[-1].get_timestamp()
+        search_time_lower_bound: int = random.randint(ts_min, ts_max)
+        search_time_upper_bound: int = random.randint(search_time_lower_bound, ts_max)
+        wildcard_queries: List[WildcardQuery] = (
+            LogGenerator.generate_random_log_type_wildcard_queries(3)
+        )
+        query: Query = Query(
+            search_time_lower_bound=search_time_lower_bound,
+            search_time_upper_bound=search_time_upper_bound,
+            wildcard_queries=wildcard_queries,
+            search_time_termination_margin=0,
+        )
+        matched_log_events: List[LogEvent] = []
+        for log_event in ref_log_events:
+            if not log_event.match_query(query):
+                continue
+            matched_log_events.append(log_event)
+        return query, matched_log_events
+
+
+class TestCaseDecoderTimeRangeWildcardQuery(TestCaseDecoderTimeRangeWildcardQueryBase):
+    """
+    Tests encoding/decoding methods against uncompressed IR stream with the query that specifies
+    both search time range and wildcard queries.
+    """
+
+    # override
+    def setUp(self) -> None:
+        self.enable_compression = False
+        self.has_query = True
+        self.num_test_iterations = 10
+        super().setUp()
+
+
+class TestCaseDecoderTimeRangeWildcardQueryZstd(TestCaseDecoderTimeRangeWildcardQueryBase):
+    """
+    Tests encoding/decoding methods against zstd compressed IR stream with the query that specifies
+    both search time range and wildcard queries.
+    """
+
+    # override
+    def setUp(self) -> None:
+        self.enable_compression = True
+        self.has_query = True
+        self.num_test_iterations = 10
+        super().setUp()

--- a/tests/test_ir/test_decoder_buffer.py
+++ b/tests/test_ir/test_decoder_buffer.py
@@ -1,0 +1,104 @@
+import io
+import random
+from pathlib import Path
+from typing import Optional
+
+from smart_open import open  # type: ignore
+from test_ir.test_utils import TestCLPBase
+
+from clp_ffi_py.ir import DecoderBuffer
+
+
+class TestCaseDecoderBuffer(TestCLPBase):
+    """
+    Class for testing clp_ffi_py.ir.DecoderBuffer.
+    """
+
+    input_src_dir: str = "test_data"
+
+    def test_buffer_protocol(self) -> None:
+        """
+        Tests whether the buffer protocol is disabled by default.
+        """
+        byte_array: bytearray = bytearray(b"Hello, world!")
+        byte_stream: io.BytesIO = io.BytesIO(byte_array)
+        decoder_buffer: DecoderBuffer = DecoderBuffer(byte_stream)
+        exception_captured: bool = False
+        try:
+            byte_stream.readinto(decoder_buffer)  # type: ignore
+        except TypeError:
+            exception_captured = True
+        self.assertTrue(
+            exception_captured, "The buffer protocol should not be enabled in Python layer."
+        )
+
+    def test_streaming_small_buffer(self) -> None:
+        """
+        Tests DecoderBuffer's functionality using the small buffer capacity.
+        """
+        buffer_capacity: int = 1024
+        self.__launch_test(buffer_capacity)
+
+    def test_streaming_default_buffer(self) -> None:
+        """
+        Tests DecoderBuffer's functionality using the default buffer capacity.
+        """
+        self.__launch_test(None)
+
+    def test_streaming_large_buffer(self) -> None:
+        """
+        Tests DecoderBuffer's functionality using the large buffer capacity.
+        """
+        buffer_capacity: int = 16384
+        self.__launch_test(buffer_capacity)
+
+    def __launch_test(self, buffer_capacity: Optional[int]) -> None:
+        """
+        Tests the DecoderBuffer by streaming the files inside `test_src_dir`.
+
+        :param self
+        :param buffer_capacity: The buffer capacity used to initialize the decoder buffer.
+        """
+        current_dir: Path = Path(__file__).resolve().parent
+        test_src_dir: Path = current_dir / TestCaseDecoderBuffer.input_src_dir
+        for file_path in test_src_dir.rglob("*"):
+            if not file_path.is_file():
+                continue
+            streaming_result: bytearray
+            decoder_buffer: DecoderBuffer
+            random_seed: int
+            # Run against 10 different seeds:
+            for _ in range(10):
+                random_seed = random.randint(1, 3190)
+                with open(str(file_path), "rb") as istream:
+                    try:
+                        if None is buffer_capacity:
+                            decoder_buffer = DecoderBuffer(istream)
+                        else:
+                            decoder_buffer = DecoderBuffer(
+                                initial_buffer_capacity=buffer_capacity, input_stream=istream
+                            )
+                        streaming_result = decoder_buffer._test_streaming(random_seed)
+                    except Exception as e:
+                        self.assertFalse(
+                            True, f"Error on file {file_path} using seed {random_seed}: {e}"
+                        )
+                self.__assert_streaming_result(file_path, streaming_result, random_seed)
+
+    def __assert_streaming_result(
+        self, file_path: Path, streaming_result: bytearray, random_seed: int
+    ) -> None:
+        """
+        Validates the streaming result read by the decoder buffer.
+
+        :param file_path: Input stream file Path.
+        :param streaming_result: Result of DecoderBuffer `_test_streaming` method.
+        """
+        with open(str(file_path), "rb") as istream:
+            ref_result: bytearray = bytearray(istream.read())
+            self.assertEqual(
+                ref_result,
+                streaming_result,
+                f"Streaming result is different from the src: {file_path}. Random seed:"
+                f" {random_seed}.",
+            )

--- a/tests/test_ir/test_encoder.py
+++ b/tests/test_ir/test_encoder.py
@@ -1,0 +1,27 @@
+from test_ir.test_utils import TestCLPBase
+
+from clp_ffi_py.ir import FourByteEncoder
+
+
+class TestCaseFourByteEncoder(TestCLPBase):
+    """
+    Class for testing clp_ffi_py.ir.FourByteEncoder.
+
+    The actual functionality should also be covered by the unittest of CLP Python logging library.
+    """
+
+    def test_encoding_methods_consistency(self) -> None:
+        """
+        This test checks if the result of encode_message_and_timestamp_delta is consistent with the
+        combination of encode_message and encode_timestamp_delta.
+        """
+        timestamp_delta: int = -3190
+        log_message: str = "This is a test message: Do NOT Reply!"
+        encoded_message_and_ts_delta: bytearray = (
+            FourByteEncoder.encode_message_and_timestamp_delta(
+                timestamp_delta, log_message.encode()
+            )
+        )
+        encoded_message: bytearray = FourByteEncoder.encode_message(log_message.encode())
+        encoded_ts_delta: bytearray = FourByteEncoder.encode_timestamp_delta(timestamp_delta)
+        self.assertEqual(encoded_message_and_ts_delta, encoded_message + encoded_ts_delta)


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
In #68, we deprecate APIs with the old naming convention, which breaks existing user code if the don't upgrade to our latest API.
This PR adds backward compatibility by creating alias to these deprecated APIs, and mark them as "deprecated":
- For `Decoder`, `DecoderBuffer`, and `FourByteEncoder`, we add a wrapper class to support deprecated renamed methods
- For `ClpXXXReader`, we add an optional argument to support renamed argument

To test this PR, we picked test cases from one [commit](https://github.com/y-scope/clp-ffi-py/tree/36e08a3d96837b5c8020ae3a4a8a19f20c910c36) before #68 and added them into the unit test. These tests can be removed once we make 0.0.13 release.

We also configured the doc site to include these alias APIs.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure the doc site is properly rendered.
- Ensure all unit tests passed with both new APIs and deprecated APIs exercised.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new module for deprecated classes, including `FourByteEncoder`, `DecoderBuffer`, and `Decoder`.
	- Added deprecation warnings for certain parameters to enhance clarity.

- **Bug Fixes**
	- Updated parameter names for consistency and clarity in the `ClpIrStreamReader` and `ClpIrFileReader` classes.

- **Tests**
	- Added comprehensive test suites for `Decoder`, `DecoderBuffer`, and `FourByteEncoder` functionalities to ensure robust performance and error handling.

- **Documentation**
	- New documentation for the `clp_ffi_py.ir.native_deprecated` module added, improving user guidance on deprecated components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->