### PR TITLE
Add required error handling steps in `PyDeserializerBuffer::py_getbuffer`.

### DIFF
--- a/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
@@ -302,7 +302,6 @@ auto PyDeserializerBuffer::py_getbuffer(Py_buffer* view, int flags) -> int {
     if (false == is_py_buffer_protocol_enabled()) {
         // The steps below are required by the spec
         // https://docs.python.org/3/c-api/typeobj.html#c.PyBufferProcs.bf_getbuffer
-        // https://docs.python.org/3/c-api/typeobj.html#c.PyBufferProcs.bf_getbuffer
         view->obj = nullptr;
         PyErr_SetString(
                 PyExc_BufferError,

--- a/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
@@ -300,8 +300,11 @@ auto PyDeserializerBuffer::metadata_init(PyMetadata* metadata) -> bool {
 
 auto PyDeserializerBuffer::py_getbuffer(Py_buffer* view, int flags) -> int {
     if (false == is_py_buffer_protocol_enabled()) {
+        // `view->obj` should be set to NULL according to the doc:
+        // https://docs.python.org/3/c-api/typeobj.html#c.PyBufferProcs.bf_getbuffer
+        view->obj = nullptr;
         PyErr_SetString(
-                PyExc_RuntimeError,
+                PyExc_BufferError,
                 "Attempted access to the internal buffer via the buffer protocol outside of "
                 "authorized methods"
         );

--- a/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
@@ -299,9 +299,12 @@ auto PyDeserializerBuffer::metadata_init(PyMetadata* metadata) -> bool {
 }
 
 auto PyDeserializerBuffer::py_getbuffer(Py_buffer* view, int flags) -> int {
-    // Don't need to set the exception message during the failure. The Python level caller will set
-    // the exception and thus overwrite it.
     if (false == is_py_buffer_protocol_enabled()) {
+        PyErr_SetString(
+                PyExc_RuntimeError,
+                "Attempted access to the internal buffer via the buffer protocol outside of "
+                "authorized methods"
+        );
         return -1;
     }
     auto const buffer{m_read_buffer.subspan(m_buffer_size, m_read_buffer.size() - m_buffer_size)};

--- a/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
@@ -300,7 +300,8 @@ auto PyDeserializerBuffer::metadata_init(PyMetadata* metadata) -> bool {
 
 auto PyDeserializerBuffer::py_getbuffer(Py_buffer* view, int flags) -> int {
     if (false == is_py_buffer_protocol_enabled()) {
-        // `view->obj` should be set to NULL according to the doc:
+        // The steps below are required by the spec
+        // https://docs.python.org/3/c-api/typeobj.html#c.PyBufferProcs.bf_getbuffer
         // https://docs.python.org/3/c-api/typeobj.html#c.PyBufferProcs.bf_getbuffer
         view->obj = nullptr;
         PyErr_SetString(


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
When running unit tests in a Python debug build with address sanitizer enabled, we get the following error:
```
test_buffer_protocol (test_ir.test_deserializer_buffer.TestCaseDeserializerBuffer)
Tests whether the buffer protocol is disabled by default. ... Fatal Python error: _Py_CheckSlotResult: Slot getbuffer of type clp_ffi_py.ir.native.DeserializerBuffer failed without setting an exception
Python runtime state: initialized
```
This is because we return failure in `PyDeserializerBuffer_getbuffer` but never set an exception. It was a mistake in the current implementation and this PR fixes the issue.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure workflow passed.
- Ensure all unit tests passed with Python (debug build with address sanitizer)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for various methods in the `PyDeserializerBuffer`, providing clearer error messages.

- **Bug Fixes**
	- Improved robustness of error reporting for buffer access and consumption issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->