### PR TITLE
fix: Invalidate non-positive buffer capacity when initializing `DeserializerBuffer`.

### DIFF
--- a/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
@@ -220,7 +220,7 @@ PyDoc_STRVAR(
 
 auto PyDeserializerBuffer::init(PyObject* input_stream, Py_ssize_t buf_capacity) -> bool {
     if (0 >= buf_capacity) {
-        PyErr_SetString(PyExc_ValueError, "The given buffer capacity must be greater than 0.");
+        PyErr_SetString(PyExc_ValueError, "Buffer capacity must be a positive integer (> 0).");
         return false;
     }
     m_read_buffer_mem_owner = static_cast<int8_t*>(PyMem_Malloc(buf_capacity));

--- a/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
@@ -219,6 +219,10 @@ PyDoc_STRVAR(
 }  // namespace
 
 auto PyDeserializerBuffer::init(PyObject* input_stream, Py_ssize_t buf_capacity) -> bool {
+    if (0 >= buf_capacity) {
+        PyErr_SetString(PyExc_ValueError, "The given buffer capacity must be greater than 0.");
+        return false;
+    }
     m_read_buffer_mem_owner = static_cast<int8_t*>(PyMem_Malloc(buf_capacity));
     if (nullptr == m_read_buffer_mem_owner) {
         PyErr_NoMemory();


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
As caught in this comment: https://github.com/y-scope/clp-ffi-py/pull/94#discussion_r1859431270, the non-positive buffer capacity is not checked when creating an instance of `DeserializerBuffer`. This PR adds the check to fail its `init` method when the buffer capacity is smaller or equal to 0.

# Validation performed
<!-- What tests and validation you performed on the change -->
Ensure workflows all passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for buffer initialization, ensuring valid capacity.
	- Improved memory management by dynamically adjusting buffer size when needed.
	- Clearer error reporting for stream reading operations with new error indications.

- **Bug Fixes**
	- Added checks to prevent overflow during buffer consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->