### PR TITLE
ci: Enable clang-tidy linting task and configure it to run on files without violations.

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -42,7 +42,8 @@ jobs:
 
       - uses: "actions/setup-python@v5"
         with:
-          python-version: "3.11"
+          # NOTE: CPython3.10 headers are used to resolve clang-tidy warnings
+          python-version: "3.10"
 
       - run: |
           pip install --upgrade pip

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -42,7 +42,8 @@ jobs:
 
       - uses: "actions/setup-python@v5"
         with:
-          # NOTE: CPython3.10 headers are used to resolve clang-tidy warnings
+          # NOTE: We resolve some of clang-tidy's IWYU violations using CPython 3.10's headers, so
+          # we need to use the same version of Python when running clang-tidy.
           python-version: "3.10"
 
       - run: |

--- a/README.md
+++ b/README.md
@@ -312,18 +312,19 @@ The commands above run all linting checks, but for performance you may want to r
 if you only changed C++ files, you don't need to run the YAML linting checks) using one of the tasks
 in the table below.
 
-| Task                    | Description                                              |
-|-------------------------|----------------------------------------------------------|
-| `lint:cmake-check`      | Runs the CMake linters.                                  |
-| `lint:cmake-fix`        | Runs the CMake linters and fixes any violations.         |
-| `lint:cpp-check`        | Runs the C++ linters (formatters and static analyzers).  |
-| `lint:cpp-fix`          | Runs the C++ linters and fixes some violations.          |
-| `lint:cpp-format-check` | Runs the C++ formatters.                                 |
-| `lint:cpp-format-fix`   | Runs the C++ formatters and fixes some violations.       |
-| `lint:py-check`         | Runs the Python linters.                                 |
-| `lint:py-fix`           | Runs the Python linters and fixes some violations.       |
-| `lint:yml-check`        | Runs the YAML linters.                                   |
-| `lint:yml-fix`          | Runs the YAML linters and fixes some violations.         |
+| Task                    | Description                                             |
+|-------------------------|---------------------------------------------------------|
+| `lint:cmake-check`      | Runs the CMake linters.                                 |
+| `lint:cmake-fix`        | Runs the CMake linters and fixes any violations.        |
+| `lint:cpp-check`        | Runs the C++ linters (formatters and static analyzers). |
+| `lint:cpp-fix`          | Runs the C++ linters and fixes some violations.         |
+| `lint:cpp-format-check` | Runs the C++ formatters.                                |
+| `lint:cpp-format-fix`   | Runs the C++ formatters and fixes some violations.      |
+| `lint:cpp-static-check` | Runs the C++ linters.                                   |
+| `lint:py-check`         | Runs the Python linters.                                |
+| `lint:py-fix`           | Runs the Python linters and fixes some violations.      |
+| `lint:yml-check`        | Runs the YAML linters.                                  |
+| `lint:yml-fix`          | Runs the YAML linters and fixes some violations.        |
 
 [1]: https://github.com/y-scope/clp/tree/main/components/core
 [2]: https://github.com/y-scope/clp

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ in the table below.
 | `lint:cpp-fix`          | Runs the C++ linters and fixes some violations.         |
 | `lint:cpp-format-check` | Runs the C++ formatters.                                |
 | `lint:cpp-format-fix`   | Runs the C++ formatters and fixes some violations.      |
-| `lint:cpp-static-check` | Runs the C++ linters.                                   |
+| `lint:cpp-static-check` | Runs the C++ static analyzers.                          |
 | `lint:py-check`         | Runs the Python linters.                                |
 | `lint:py-fix`           | Runs the Python linters and fixes some violations.      |
 | `lint:yml-check`        | Runs the YAML linters.                                  |

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -4,7 +4,12 @@ vars:
   G_LINT_VENV_DIR: "{{.BUILD_DIR}}/lint-venv"
   G_LINT_VENV_CHECKSUM_FILE: "{{.BUILD_DIR}}/lint#venv.md5"
   # Linter target dirs
-  G_CPP_LINT_DIRS: ["{{.CLP_FFI_PY_CPP_SRC_DIR}}"]
+  G_CPP_LINT_DIRS:
+    # TODO: before all clang-tidy warnings are resolved, we should maintain a list of files that
+    # doesn't have clang-tidy warnings, so that clang-tidy can be executed in the limited scope
+    # without failing existing workflows.
+    - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.cpp"
+    - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.hpp"
   G_PYTHON_LINT_DIRS: ["{{.ROOT_DIR}}/clp_ffi_py", "{{.ROOT_DIR}}/tests"]
 
 tasks:
@@ -37,22 +42,18 @@ tasks:
           FLAGS: "--in-place"
 
   cpp-configs:
-    # TODO: remove this once all clang-tidy has been fixed
-    deps: [":config-cmake-project"]
     cmds:
       - "tools/yscope-dev-utils/lint-configs/symlink-cpp-lint-configs.sh"
 
   cpp-check:
     cmds:
       - task: "cpp-format-check"
-      # TODO: re-enable this once all clang-tidy has been fixed
-      # - task: "cpp-static-check"
+      - task: "cpp-static-check"
 
   cpp-fix:
     cmds:
       - task: "cpp-format-fix"
-      # TODO: re-enable this once all clang-tidy has been fixed
-      # - task: "cpp-static-fix"
+      - task: "cpp-static-fix"
 
   cpp-format-check:
     sources: &cpp_format_src_files

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -5,12 +5,6 @@ vars:
   G_LINT_VENV_CHECKSUM_FILE: "{{.BUILD_DIR}}/lint#venv.md5"
   # Linter target dirs
   G_CPP_LINT_DIRS: ["{{.CLP_FFI_PY_CPP_SRC_DIR}}"]
-  G_CPP_STATIC_CHECK_SRC_FILES:
-    # TODO: Before all clang-tidy violations are resolved, we should only run clang-tidy on the
-    # files whose violations we've fixed, both to ensure they remain free of violations and so that
-    # the workflow doesn't fail due to violations in other files.
-    - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.cpp"
-    - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.hpp"
   G_PYTHON_LINT_DIRS: ["{{.ROOT_DIR}}/clp_ffi_py", "{{.ROOT_DIR}}/tests"]
 
 tasks:
@@ -109,7 +103,11 @@ tasks:
             --config-file "{{.CLP_FFI_PY_CPP_SRC_DIR}}/.clang-tidy"
             -p "{{.CLP_FFI_PY_COMPILE_COMMANDS_DB}}"
           SRC_PATHS:
-            ref: ".G_CPP_STATIC_CHECK_SRC_FILES"
+            # TODO: Before all clang-tidy violations are resolved, we should only run clang-tidy on
+            # the files whose violations we've fixed, both to ensure they remain free of violations
+            # and so that the workflow doesn't fail due to violations in other files.
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.cpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.hpp"
           VENV_DIR: "{{.G_LINT_VENV_DIR}}"
 
   py-check:

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -5,9 +5,9 @@ vars:
   G_LINT_VENV_CHECKSUM_FILE: "{{.BUILD_DIR}}/lint#venv.md5"
   # Linter target dirs
   G_CPP_LINT_DIRS:
-    # TODO: before all clang-tidy warnings are resolved, we should maintain a list of files that
-    # doesn't have clang-tidy warnings, so that clang-tidy can be executed in the limited scope
-    # without failing existing workflows.
+    # TODO: Before all clang-tidy violations are resolved, we should only run clang-tidy on the
+    # files whose violations we've fixed, both to ensure they remain free of violations and so that
+    # the workflow doesn't fail due to violations in other files.
     - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.cpp"
     - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.hpp"
   G_PYTHON_LINT_DIRS: ["{{.ROOT_DIR}}/clp_ffi_py", "{{.ROOT_DIR}}/tests"]

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -4,7 +4,8 @@ vars:
   G_LINT_VENV_DIR: "{{.BUILD_DIR}}/lint-venv"
   G_LINT_VENV_CHECKSUM_FILE: "{{.BUILD_DIR}}/lint#venv.md5"
   # Linter target dirs
-  G_CPP_LINT_DIRS:
+  G_CPP_LINT_DIRS: ["{{.CLP_FFI_PY_CPP_SRC_DIR}}"]
+  G_CPP_STATIC_CHECK_SRC_FILES:
     # TODO: Before all clang-tidy violations are resolved, we should only run clang-tidy on the
     # files whose violations we've fixed, both to ensure they remain free of violations and so that
     # the workflow doesn't fail due to violations in other files.
@@ -108,7 +109,7 @@ tasks:
             --config-file "{{.CLP_FFI_PY_CPP_SRC_DIR}}/.clang-tidy"
             -p "{{.CLP_FFI_PY_COMPILE_COMMANDS_DB}}"
           SRC_PATHS:
-            ref: ".G_CPP_LINT_DIRS"
+            ref: ".G_CPP_STATIC_CHECK_SRC_FILES"
           VENV_DIR: "{{.G_LINT_VENV_DIR}}"
 
   py-check:


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
clang-tidy checks are current turned off since warnings are not resolved. As mentioned in #96, we have a sequence of PRs to resolve these warnings. This PR re-opens clang-tidy but only executes against resolved files.

# Validation performed
<!-- What tests and validation you performed on the change -->
Ensure linting workflow passed: https://github.com/LinZhihao-723/clp-ffi-py/actions/runs/12112121114/job/33765065139



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated compatibility requirements in the README to require Python 3.7 or higher.
	- Introduced a new requirement for C++ linting in the README.
	- Enhanced C++ linting tasks by specifying target files and re-enabling static checks.

- **Bug Fixes**
	- Adjusted Python version in the linting workflow to improve compatibility checks.

- **Documentation**
	- Clarified installation and compatibility information in the README, including the removal of support for Python 3.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->