### PR TITLE
refactor: Fix clang-tidy warnings in `utils`.

### DIFF
--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -111,6 +111,8 @@ tasks:
             # and so that the workflow doesn't fail due to violations in other files.
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.cpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.hpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/utils.cpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/utils.hpp"
             - "{{.G_CPP_WRAPPED_FACADE_HEADERS_DIR}}"
           VENV_DIR: "{{.G_LINT_VENV_DIR}}"
 

--- a/src/clp_ffi_py/.clang-tidy
+++ b/src/clp_ffi_py/.clang-tidy
@@ -1,5 +1,9 @@
 InheritParentConfig: true
 
+Checks:
+  # Disable vararg function checks since many CPython APIs are using varargs
+  -cppcoreguidelines-pro-type-vararg
+
 CheckOptions:
   # Variable naming rules
   # Allow PyObject global variables to start with `Py_`

--- a/src/clp_ffi_py/utils.cpp
+++ b/src/clp_ffi_py/utils.cpp
@@ -2,9 +2,9 @@
 
 #include "utils.hpp"
 
-#include <iostream>
 #include <span>
 #include <string>
+#include <string_view>
 
 #include <clp/TraceableException.hpp>
 #include <outcome/single-header/outcome.hpp>
@@ -32,7 +32,6 @@ auto get_py_string_data(PyObject* py_string) -> char const* {
 }  // namespace
 
 auto add_python_type(PyTypeObject* new_type, char const* type_name, PyObject* module) -> bool {
-    assert(new_type);
     if (PyType_Ready(new_type) < 0) {
         return false;
     }
@@ -56,7 +55,7 @@ auto parse_py_string_as_string_view(PyObject* py_string, std::string_view& view)
     if (nullptr == str) {
         return false;
     }
-    view = std::string_view(str);
+    view = std::string_view{str};
     return true;
 }
 

--- a/src/wrapped_facade_headers/msgpack.hpp
+++ b/src/wrapped_facade_headers/msgpack.hpp
@@ -6,7 +6,12 @@
 #ifdef CLP_FFI_PY_ENABLE_LINTING
 // Inform IWYU of the headers that we use that are exported by msgpack.hpp
 // IWYU pragma: begin_exports
-// TODO: Add necessary msgpack internal headers to silence clang-tidy warnings
+#include <msgpack/v1/object_decl.hpp>
+#include "msgpack/v1/unpack_decl.hpp"
+#include <msgpack/v2/object_decl.hpp>
+#include "msgpack/v2/unpack_decl.hpp"
+#include <msgpack/v3/object_decl.hpp>
+#include "msgpack/v3/unpack_decl.hpp"
 // IWYU pragma: end_exports
 #endif
 // clang-format on


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This is one of the PRs to implement #96.
This PR fixes all clang-tidy warnings in `utils.hpp/cpp`.
Note: `cppcoreguidelines-pro-type-vararg` is disabled since vararg functions are used in many CPython APIs.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure the lint workflow passed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced C++ linting capabilities with additional source paths for static analysis.
	- Updated linting configurations to improve compatibility with CPython coding practices.

- **Improvements**
	- Standardized initialization syntax in utility functions for better code clarity.
	- Enhanced type safety and clarity in function signatures and template usage.

- **Bug Fixes**
	- Addressed potential clang-tidy warnings by including necessary Msgpack declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->