### PR TITLE
refactor: Fix clang-tidy warnings for the rest of files directly under `src/clp_ffi_py`; Use `std::string_view` for static error message strings.

### DIFF
--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -109,8 +109,14 @@ tasks:
             # TODO: Before all clang-tidy violations are resolved, we should only run clang-tidy on
             # the files whose violations we've fixed, both to ensure they remain free of violations
             # and so that the workflow doesn't fail due to violations in other files.
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/api_decoration.hpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/error_messages.hpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ExceptionFFI.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.cpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.hpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/PyExceptionContext.hpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/PyObjectCast.hpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/PyObjectUtils.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/utils.cpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/utils.hpp"
             - "{{.G_CPP_WRAPPED_FACADE_HEADERS_DIR}}"

--- a/src/clp_ffi_py/PyObjectCast.hpp
+++ b/src/clp_ffi_py/PyObjectCast.hpp
@@ -57,7 +57,7 @@ auto py_releasebufferproc_cast(Src src) noexcept -> releasebufferproc {
  * @tparam T
  */
 template <typename T>
-struct is_python_object {
+struct IsPythonObject {
     static constexpr bool cValue = false;
 };
 
@@ -67,7 +67,7 @@ struct is_python_object {
  * @tparam T
  */
 template <typename T>  // NOLINTNEXTLINE(readability-identifier-naming)
-constexpr bool is_python_object_v{is_python_object<T>::cValue};
+constexpr bool is_python_object_v{IsPythonObject<T>::cValue};
 
 /**
  * The macro to create a specialization of is_python_object for a given type T. Only types that are
@@ -76,7 +76,7 @@ constexpr bool is_python_object_v{is_python_object<T>::cValue};
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define CLP_FFI_PY_MARK_AS_PYOBJECT(T) \
     template <> \
-    struct is_python_object<T> { \
+    struct IsPythonObject<T> { \
         static constexpr bool cValue = true; \
     }
 

--- a/src/clp_ffi_py/PyObjectCast.hpp
+++ b/src/clp_ffi_py/PyObjectCast.hpp
@@ -62,7 +62,7 @@ struct IsPythonObject {
 };
 
 /**
- * This template const expression is a wrapper of underlying `cValue` stored in `is_python_object`,
+ * This template const expression is a wrapper of underlying `cValue` stored in `IsPythonObject`,
  * which is used to determine whether a type T is a valid Python object type.
  * @tparam T
  */
@@ -70,7 +70,7 @@ template <typename T>  // NOLINTNEXTLINE(readability-identifier-naming)
 constexpr bool is_python_object_v{IsPythonObject<T>::cValue};
 
 /**
- * The macro to create a specialization of is_python_object for a given type T. Only types that are
+ * The macro to create a specialization of `IsPythonObject` for a given type T. Only types that are
  * marked with this macro will be considered as a valid Python object type.
  */
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)

--- a/src/clp_ffi_py/error_messages.hpp
+++ b/src/clp_ffi_py/error_messages.hpp
@@ -1,14 +1,18 @@
 #ifndef CLP_FFI_PY_ERROR_MESSAGES
 #define CLP_FFI_PY_ERROR_MESSAGES
 
+#include <string_view>
+
 namespace clp_ffi_py {
-constexpr char const* const cOutofMemoryError = "Failed to allocate memory.";
-constexpr char const* const cPyTypeError = "Wrong Python Type received.";
-constexpr char const* const cSetstateInputError
-        = "Python dictionary is expected to be the input of __setstate__ method.";
-constexpr char const* const cSetstateKeyErrorTemplate = "\"%s\" not found in the state dictionary.";
-constexpr char const* const cTimezoneObjectNotInitialzed
-        = "Timezone (tzinfo) object is not yet initialized.";
+constexpr std::string_view cOutOfMemoryError{"Failed to allocate memory."};
+constexpr std::string_view cPyTypeError{"Wrong Python Type received."};
+constexpr std::string_view cSetstateInputError{
+        "Python dictionary is expected to be the input of __setstate__ method."
+};
+constexpr std::string_view cSetstateKeyErrorTemplate{"\"%s\" not found in the state dictionary."};
+constexpr std::string_view cTimezoneObjectNotInitialized{
+        "Timezone (tzinfo) object is not yet initialized."
+};
 }  // namespace clp_ffi_py
 
 #endif  // CLP_FFI_PY_ERROR_MESSAGES

--- a/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
@@ -385,7 +385,10 @@ auto PyDeserializerBuffer::create(PyObject* input_stream, Py_ssize_t buf_capacit
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
     PyDeserializerBuffer* self{PyObject_New(PyDeserializerBuffer, get_py_type())};
     if (nullptr == self) {
-        PyErr_SetString(PyExc_MemoryError, clp_ffi_py::cOutofMemoryError);
+        PyErr_SetString(
+                PyExc_MemoryError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cOutOfMemoryError)
+        );
         return nullptr;
     }
     self->default_init();

--- a/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.cpp
+++ b/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.cpp
@@ -4,7 +4,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <new>
 #include <optional>
 #include <span>
 #include <stack>
@@ -643,8 +642,7 @@ auto decode_as_encoded_text_ast(Value const& val) -> std::optional<std::string> 
 }  // namespace
 
 auto PyKeyValuePairLogEvent::init(clp::ffi::KeyValuePairLogEvent kv_pair_log_event) -> bool {
-    m_kv_pair_log_event
-            = new (std::nothrow) clp::ffi::KeyValuePairLogEvent{std::move(kv_pair_log_event)};
+    m_kv_pair_log_event = new clp::ffi::KeyValuePairLogEvent{std::move(kv_pair_log_event)};
     if (nullptr == m_kv_pair_log_event) {
         PyErr_SetString(
                 PyExc_RuntimeError,

--- a/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.cpp
+++ b/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.cpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <new>
 #include <optional>
 #include <span>
 #include <stack>
@@ -642,9 +643,13 @@ auto decode_as_encoded_text_ast(Value const& val) -> std::optional<std::string> 
 }  // namespace
 
 auto PyKeyValuePairLogEvent::init(clp::ffi::KeyValuePairLogEvent kv_pair_log_event) -> bool {
-    m_kv_pair_log_event = new clp::ffi::KeyValuePairLogEvent{std::move(kv_pair_log_event)};
+    m_kv_pair_log_event
+            = new (std::nothrow) clp::ffi::KeyValuePairLogEvent{std::move(kv_pair_log_event)};
     if (nullptr == m_kv_pair_log_event) {
-        PyErr_SetString(PyExc_RuntimeError, clp_ffi_py::cOutofMemoryError);
+        PyErr_SetString(
+                PyExc_RuntimeError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cOutOfMemoryError)
+        );
         return false;
     }
     return true;
@@ -679,7 +684,6 @@ auto PyKeyValuePairLogEvent::create(clp::ffi::KeyValuePairLogEvent kv_log_event
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
     PyKeyValuePairLogEvent* self{PyObject_New(PyKeyValuePairLogEvent, get_py_type())};
     if (nullptr == self) {
-        PyErr_SetString(PyExc_MemoryError, clp_ffi_py::cOutofMemoryError);
         return nullptr;
     }
     self->default_init();

--- a/src/clp_ffi_py/ir/native/PyLogEvent.cpp
+++ b/src/clp_ffi_py/ir/native/PyLogEvent.cpp
@@ -2,8 +2,6 @@
 
 #include "PyLogEvent.hpp"
 
-#include <new>
-
 #include <clp_ffi_py/error_messages.hpp>
 #include <clp_ffi_py/ir/native/LogEvent.hpp>
 #include <clp_ffi_py/ir/native/PyQuery.hpp>
@@ -496,7 +494,7 @@ auto PyLogEvent::init(
         std::optional<std::string_view> formatted_timestamp
 ) -> bool {
     // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-    m_log_event = new (std::nothrow) LogEvent(log_message, timestamp, index, formatted_timestamp);
+    m_log_event = new LogEvent(log_message, timestamp, index, formatted_timestamp);
     if (nullptr == m_log_event) {
         PyErr_SetString(
                 PyExc_RuntimeError,

--- a/src/clp_ffi_py/ir/native/PyMetadata.cpp
+++ b/src/clp_ffi_py/ir/native/PyMetadata.cpp
@@ -139,7 +139,10 @@ PyDoc_STRVAR(
 auto PyMetadata_get_timezone(PyMetadata* self) -> PyObject* {
     auto* timezone{self->get_py_timezone()};
     if (nullptr == timezone) {
-        PyErr_SetString(PyExc_RuntimeError, clp_ffi_py::cTimezoneObjectNotInitialzed);
+        PyErr_SetString(
+                PyExc_RuntimeError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cTimezoneObjectNotInitialized)
+        );
         return nullptr;
     }
     Py_INCREF(timezone);
@@ -227,7 +230,10 @@ auto PyMetadata::init(
     // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     m_metadata = new Metadata(ref_timestamp, input_timestamp_format, input_timezone);
     if (nullptr == m_metadata) {
-        PyErr_SetString(PyExc_RuntimeError, clp_ffi_py::cOutofMemoryError);
+        PyErr_SetString(
+                PyExc_RuntimeError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cOutOfMemoryError)
+        );
         return false;
     }
     return init_py_timezone();
@@ -243,7 +249,10 @@ auto PyMetadata::init(nlohmann::json const& metadata, bool is_four_byte_encoding
         return false;
     }
     if (nullptr == m_metadata) {
-        PyErr_SetString(PyExc_RuntimeError, clp_ffi_py::cOutofMemoryError);
+        PyErr_SetString(
+                PyExc_RuntimeError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cOutOfMemoryError)
+        );
         return false;
     }
     return init_py_timezone();

--- a/src/clp_ffi_py/ir/native/PyQuery.cpp
+++ b/src/clp_ffi_py/ir/native/PyQuery.cpp
@@ -3,8 +3,6 @@
 
 #include "PyQuery.hpp"
 
-#include <new>
-
 #include <clp/string_utils/string_utils.hpp>
 
 #include <clp_ffi_py/error_messages.hpp>
@@ -629,11 +627,12 @@ auto PyQuery::init(
 ) -> bool {
     try {
         // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-        m_query = new (std::nothrow)
-                Query(search_time_lower_bound,
-                      search_time_upper_bound,
-                      wildcard_queries,
-                      search_time_termination_margin);
+        m_query = new Query(
+                search_time_lower_bound,
+                search_time_upper_bound,
+                wildcard_queries,
+                search_time_termination_margin
+        );
         if (nullptr == m_query) {
             PyErr_SetString(
                     PyExc_RuntimeError,

--- a/src/clp_ffi_py/ir/native/PySerializer.cpp
+++ b/src/clp_ffi_py/ir/native/PySerializer.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <new>
 #include <optional>
 #include <span>
 #include <type_traits>
@@ -400,10 +401,13 @@ auto PySerializer::init(
 ) -> bool {
     m_output_stream = output_stream;
     Py_INCREF(output_stream);
-    m_serializer = new PySerializer::ClpIrSerializer{std::move(serializer)};
+    m_serializer = new (std::nothrow) PySerializer::ClpIrSerializer{std::move(serializer)};
     m_buffer_size_limit = buffer_size_limit;
     if (nullptr == m_serializer) {
-        PyErr_SetString(PyExc_RuntimeError, clp_ffi_py::cOutofMemoryError);
+        PyErr_SetString(
+                PyExc_RuntimeError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cOutOfMemoryError)
+        );
         return false;
     }
     auto const preamble_size{get_ir_buf_size()};

--- a/src/clp_ffi_py/ir/native/PySerializer.cpp
+++ b/src/clp_ffi_py/ir/native/PySerializer.cpp
@@ -401,7 +401,7 @@ auto PySerializer::init(
 ) -> bool {
     m_output_stream = output_stream;
     Py_INCREF(output_stream);
-    m_serializer = new (std::nothrow) PySerializer::ClpIrSerializer{std::move(serializer)};
+    m_serializer = new PySerializer::ClpIrSerializer{std::move(serializer)};
     m_buffer_size_limit = buffer_size_limit;
     if (nullptr == m_serializer) {
         PyErr_SetString(

--- a/src/clp_ffi_py/ir/native/deserialization_methods.cpp
+++ b/src/clp_ffi_py/ir/native/deserialization_methods.cpp
@@ -184,7 +184,7 @@ auto deserialize_preamble(PyObject* Py_UNUSED(self), PyObject* py_deserializer_b
                 PyObject_TypeCheck(py_deserializer_buffer, PyDeserializerBuffer::get_py_type())
         ))
     {
-        PyErr_SetString(PyExc_TypeError, cPyTypeError);
+        PyErr_SetString(PyExc_TypeError, get_c_str_from_constexpr_string_view(cPyTypeError));
         return nullptr;
     }
 
@@ -329,7 +329,7 @@ auto deserialize_next_log_event(PyObject* Py_UNUSED(self), PyObject* args, PyObj
     if (is_query_given
         && false == static_cast<bool>(PyObject_TypeCheck(query_obj, PyQuery::get_py_type())))
     {
-        PyErr_SetString(PyExc_TypeError, cPyTypeError);
+        PyErr_SetString(PyExc_TypeError, get_c_str_from_constexpr_string_view(cPyTypeError));
         return nullptr;
     }
 

--- a/src/clp_ffi_py/utils.hpp
+++ b/src/clp_ffi_py/utils.hpp
@@ -95,9 +95,7 @@ template <typename T>
  * @return The underlying C-string of the given constexpr string view.
  */
 [[nodiscard]] consteval auto get_c_str_from_constexpr_string_view(std::string_view const& sv
-) -> char const* {
-    return sv.data();
-}
+) -> char const*;
 
 template <clp::IntegerType IntType>
 auto parse_py_int(PyObject* py_int, IntType& val) -> bool {
@@ -131,6 +129,10 @@ auto parse_py_int(PyObject* py_int, IntType& val) -> bool {
     }
 
     return (nullptr == PyErr_Occurred());
+}
+
+consteval auto get_c_str_from_constexpr_string_view(std::string_view const& sv) -> char const* {
+    return sv.data();
 }
 }  // namespace clp_ffi_py
 


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This is one of the PR series trying to implement #96 
This PR fixes all clang-tidy warnings for the rest of the files directly under `src/clp_ffi_py` (not the inner directories).
Also, it refactors `error_messages.hpp` to use `std::string_view` to replace the use of `char const*` for constexpr static strings. This change propagates to the files that use these error messages, to update them to use string_view instead.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure workflow passed without linting issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling across multiple components for improved clarity and consistency.
	- Updated error message management to utilize a new utility function for string retrieval.

- **Bug Fixes**
	- Corrected variable names and types in error message constants for better type safety.

- **Documentation**
	- Minor adjustments made to comments and documentation strings for improved clarity.

- **Chores**
	- Refined error handling logic in various classes to ensure robust responses to exceptional conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->