### PR TITLE
refactor: Fix clang-tidy warnings in `ir_native.cpp`.

### DIFF
--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -112,6 +112,7 @@ tasks:
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/api_decoration.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/error_messages.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ExceptionFFI.hpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/modules"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.cpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/PyExceptionContext.hpp"

--- a/src/clp_ffi_py/modules/ir_native.cpp
+++ b/src/clp_ffi_py/modules/ir_native.cpp
@@ -18,7 +18,8 @@ PyDoc_STRVAR(
         "Python interface to the CLP IR serialization and deserialization methods."
 );
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
 PyMethodDef Py_native_method_table[]{{nullptr, nullptr, 0, nullptr}};
 
 PyModuleDef Py_native{
@@ -28,9 +29,11 @@ PyModuleDef Py_native{
         -1,
         static_cast<PyMethodDef*>(Py_native_method_table)
 };
+
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 }  // namespace
 
-// NOLINTNEXTLINE(modernize-use-trailing-return-type)
+// NOLINTNEXTLINE(modernize-use-trailing-return-type, readability-identifier-naming)
 PyMODINIT_FUNC PyInit_native() {
     PyObject* new_module{PyModule_Create(&Py_native)};
     if (nullptr == new_module) {

--- a/src/wrapped_facade_headers/Python.hpp
+++ b/src/wrapped_facade_headers/Python.hpp
@@ -25,6 +25,7 @@
 #include <memoryobject.h>
 #include <methodobject.h>
 #include <modsupport.h>
+#include <moduleobject.h>
 #include <object.h>
 #include <objimpl.h>
 #include <pyerrors.h>


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This is one of the PR series trying to implement https://github.com/y-scope/clp-ffi-py/issues/96
This PR fixes all clang-tidy warnings in `ir_native.cpp`.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure linting workflow passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded static analysis to include additional source files in the `modules` directory.
	- Added a new header file to improve dependency management.

- **Bug Fixes**
	- Updated linting comments to suppress specific warnings, enhancing code quality without altering functionality.

- **Documentation**
	- Improved documentation comments for better clarity and adherence to coding standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->