### PR TITLE
fix: Use `std::nothrow` to disable exceptions throwing in `new` operators (fixes #103).

### DIFF
--- a/src/clp_ffi_py/ir/native/DeserializerBufferReader.cpp
+++ b/src/clp_ffi_py/ir/native/DeserializerBufferReader.cpp
@@ -5,15 +5,18 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <new>
 #include <span>
 
 #include <clp/ErrorCode.hpp>
 #include <clp/type_utils.hpp>
 #include <gsl/gsl>
 
+#include <clp_ffi_py/error_messages.hpp>
 #include <clp_ffi_py/ExceptionFFI.hpp>
 #include <clp_ffi_py/ir/native/PyDeserializerBuffer.hpp>
 #include <clp_ffi_py/PyObjectUtils.hpp>
+#include <clp_ffi_py/utils.hpp>
 
 namespace clp_ffi_py::ir::native {
 auto DeserializerBufferReader::create(PyObject* input_stream, Py_ssize_t buf_capacity)
@@ -24,7 +27,16 @@ auto DeserializerBufferReader::create(PyObject* input_stream, Py_ssize_t buf_cap
     if (nullptr == py_deserializer_buffer) {
         return nullptr;
     }
-    return new DeserializerBufferReader{py_deserializer_buffer.get()};
+    gsl::owner<DeserializerBufferReader*> reader{new (std::nothrow
+    ) DeserializerBufferReader{py_deserializer_buffer.get()}};
+    if (nullptr == reader) {
+        PyErr_SetString(
+                PyExc_RuntimeError,
+                get_c_str_from_constexpr_string_view(cOutOfMemoryError)
+        );
+        return nullptr;
+    }
+    return reader;
 }
 
 auto DeserializerBufferReader::try_read(char* buf, size_t num_bytes_to_read, size_t& num_bytes_read)

--- a/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.cpp
+++ b/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.cpp
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <new>
 #include <optional>
 #include <span>
 #include <stack>
@@ -642,7 +643,8 @@ auto decode_as_encoded_text_ast(Value const& val) -> std::optional<std::string> 
 }  // namespace
 
 auto PyKeyValuePairLogEvent::init(clp::ffi::KeyValuePairLogEvent kv_pair_log_event) -> bool {
-    m_kv_pair_log_event = new clp::ffi::KeyValuePairLogEvent{std::move(kv_pair_log_event)};
+    m_kv_pair_log_event
+            = new (std::nothrow) clp::ffi::KeyValuePairLogEvent{std::move(kv_pair_log_event)};
     if (nullptr == m_kv_pair_log_event) {
         PyErr_SetString(
                 PyExc_RuntimeError,

--- a/src/clp_ffi_py/ir/native/PyLogEvent.cpp
+++ b/src/clp_ffi_py/ir/native/PyLogEvent.cpp
@@ -2,6 +2,8 @@
 
 #include "PyLogEvent.hpp"
 
+#include <new>
+
 #include <clp_ffi_py/error_messages.hpp>
 #include <clp_ffi_py/ir/native/LogEvent.hpp>
 #include <clp_ffi_py/ir/native/PyQuery.hpp>
@@ -494,7 +496,7 @@ auto PyLogEvent::init(
         std::optional<std::string_view> formatted_timestamp
 ) -> bool {
     // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-    m_log_event = new LogEvent(log_message, timestamp, index, formatted_timestamp);
+    m_log_event = new (std::nothrow) LogEvent(log_message, timestamp, index, formatted_timestamp);
     if (nullptr == m_log_event) {
         PyErr_SetString(
                 PyExc_RuntimeError,

--- a/src/clp_ffi_py/ir/native/PyQuery.cpp
+++ b/src/clp_ffi_py/ir/native/PyQuery.cpp
@@ -3,6 +3,8 @@
 
 #include "PyQuery.hpp"
 
+#include <new>
+
 #include <clp/string_utils/string_utils.hpp>
 
 #include <clp_ffi_py/error_messages.hpp>
@@ -627,12 +629,11 @@ auto PyQuery::init(
 ) -> bool {
     try {
         // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-        m_query = new Query(
-                search_time_lower_bound,
-                search_time_upper_bound,
-                wildcard_queries,
-                search_time_termination_margin
-        );
+        m_query = new (std::nothrow)
+                Query(search_time_lower_bound,
+                      search_time_upper_bound,
+                      wildcard_queries,
+                      search_time_termination_margin);
         if (nullptr == m_query) {
             PyErr_SetString(
                     PyExc_RuntimeError,

--- a/src/clp_ffi_py/ir/native/PySerializer.cpp
+++ b/src/clp_ffi_py/ir/native/PySerializer.cpp
@@ -401,8 +401,8 @@ auto PySerializer::init(
 ) -> bool {
     m_output_stream = output_stream;
     Py_INCREF(output_stream);
-    m_serializer = new PySerializer::ClpIrSerializer{std::move(serializer)};
     m_buffer_size_limit = buffer_size_limit;
+    m_serializer = new (std::nothrow) PySerializer::ClpIrSerializer{std::move(serializer)};
     if (nullptr == m_serializer) {
         PyErr_SetString(
                 PyExc_RuntimeError,


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR fixes #103.
For all `new` operators, we now use `std::nothrow` to explicitly disable exception throwing. As a result, we need to check manually whether the returned pointer is null and set out-of-memory errors accordingly.


# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure workflows passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced memory management and error handling across various components, ensuring improved stability during memory allocation.
  
- **Bug Fixes**
	- Implemented robust error handling for memory allocation failures, preventing potential crashes and ensuring appropriate error messages are raised.

- **Documentation**
	- Updated comments and documentation strings for clarity regarding method parameters and expected behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->