### PR TITLE
ci(clang-format): Update to clang-format v19 (and the corresponding yscope-dev-utils) and apply the corresponding formatting changes (fixes #71).

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 black>=24.4.2
 build>=0.8.0
 cibuildwheel>=2.16.2
-# Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
 clang-format>=19.1.6
 clang-tidy>=19.1.0
 docformatter>=1.7.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ black>=24.4.2
 build>=0.8.0
 cibuildwheel>=2.16.2
 # Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
-clang-format~=18.1
+clang-format>=19.1.6
 clang-tidy>=19.1.0
 docformatter>=1.7.5
 gersemi>=0.16.2

--- a/src/clp_ffi_py/ExceptionFFI.hpp
+++ b/src/clp_ffi_py/ExceptionFFI.hpp
@@ -24,7 +24,7 @@ public:
             std::string message
     )
             : TraceableException{error_code, filename, line_number},
-              m_message{std::move(message)} {};
+              m_message{std::move(message)} {}
 
     [[nodiscard]] auto what() const noexcept -> char const* override { return m_message.c_str(); }
 

--- a/src/clp_ffi_py/Py_utils.hpp
+++ b/src/clp_ffi_py/Py_utils.hpp
@@ -24,10 +24,9 @@ namespace clp_ffi_py {
  * @return a new reference of a PyObject string that stores the formatted timestamp.
  * @return nullptr on failure with the relevant Python exception and error set.
  */
-[[nodiscard]] auto py_utils_get_formatted_timestamp(
-        clp::ir::epoch_time_ms_t timestamp,
-        PyObject* timezone
-) -> PyObject*;
+[[nodiscard]] auto
+py_utils_get_formatted_timestamp(clp::ir::epoch_time_ms_t timestamp, PyObject* timezone)
+        -> PyObject*;
 
 /**
  * CPython wrapper of `clp_ffi_py.utils.get_timezone_from_timezone_id`.
@@ -35,8 +34,8 @@ namespace clp_ffi_py {
  * @return a new reference of a Python tzinfo object that matches the input timezone id.
  * @return nullptr on failure with the relevant Python exception and error set.
  */
-[[nodiscard]] auto py_utils_get_timezone_from_timezone_id(std::string const& timezone_id
-) -> PyObject*;
+[[nodiscard]] auto py_utils_get_timezone_from_timezone_id(std::string const& timezone_id)
+        -> PyObject*;
 
 /**
  * CPython wrapper of `clp_ffi_py.utils.serialize_dict_to_msgpack`.

--- a/src/clp_ffi_py/ir/native/Metadata.hpp
+++ b/src/clp_ffi_py/ir/native/Metadata.hpp
@@ -39,7 +39,7 @@ public:
             : m_is_four_byte_encoding{true},
               m_ref_timestamp{ref_timestamp},
               m_timestamp_format{std::move(timestamp_format)},
-              m_timezone_id{std::move(timezone)} {};
+              m_timezone_id{std::move(timezone)} {}
 
     [[nodiscard]] auto is_using_four_byte_encoding() const -> bool {
         return m_is_four_byte_encoding;

--- a/src/clp_ffi_py/ir/native/PyDeserializer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializer.cpp
@@ -48,8 +48,8 @@ PyDoc_STRVAR(
         " treated as an error.\n"
         ":type allow_incomplete_stream: bool\n"
 );
-CLP_FFI_PY_METHOD auto
-PyDeserializer_init(PyDeserializer* self, PyObject* args, PyObject* keywords) -> int;
+CLP_FFI_PY_METHOD auto PyDeserializer_init(PyDeserializer* self, PyObject* args, PyObject* keywords)
+        -> int;
 
 /**
  * Callback of `PyDeserializer`'s `deserialize_log_event`.
@@ -105,8 +105,8 @@ PyType_Spec PyDeserializer_type_spec{
         static_cast<PyType_Slot*>(PyDeserializer_slots)
 };
 
-CLP_FFI_PY_METHOD auto
-PyDeserializer_init(PyDeserializer* self, PyObject* args, PyObject* keywords) -> int {
+CLP_FFI_PY_METHOD auto PyDeserializer_init(PyDeserializer* self, PyObject* args, PyObject* keywords)
+        -> int {
     static char keyword_input_stream[]{"input_stream"};
     static char keyword_buffer_capacity[]{"buffer_capacity"};
     static char keyword_allow_incomplete_stream[]{"allow_incomplete_stream"};

--- a/src/clp_ffi_py/ir/native/PyDeserializer.hpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializer.hpp
@@ -151,15 +151,14 @@ private:
         ~IrUnitHandler() = default;
 
         // Implements `clp::ffi::ir_stream::IrUnitHandlerInterface` interface
-        [[nodiscard]] auto handle_log_event(clp::ffi::KeyValuePairLogEvent&& log_event
-        ) -> clp::ffi::ir_stream::IRErrorCode {
+        [[nodiscard]] auto handle_log_event(clp::ffi::KeyValuePairLogEvent&& log_event)
+                -> clp::ffi::ir_stream::IRErrorCode {
             return m_log_event_handle(std::move(log_event));
         }
 
-        [[nodiscard]] auto handle_utc_offset_change(
-                clp::UtcOffset utc_offset_old,
-                clp::UtcOffset utc_offset_new
-        ) -> clp::ffi::ir_stream::IRErrorCode {
+        [[nodiscard]] auto
+        handle_utc_offset_change(clp::UtcOffset utc_offset_old, clp::UtcOffset utc_offset_new)
+                -> clp::ffi::ir_stream::IRErrorCode {
             return m_utc_offset_change_handle(utc_offset_old, utc_offset_new);
         }
 
@@ -201,8 +200,8 @@ private:
      * @return IRErrorCode::IRErrorCode_Success on success.
      *
      */
-    [[nodiscard]] auto handle_log_event(clp::ffi::KeyValuePairLogEvent&& log_event
-    ) -> clp::ffi::ir_stream::IRErrorCode;
+    [[nodiscard]] auto handle_log_event(clp::ffi::KeyValuePairLogEvent&& log_event)
+            -> clp::ffi::ir_stream::IRErrorCode;
 
     /**
      * @return Whether `m_deserialized_log_event` has been set.

--- a/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
@@ -118,8 +118,8 @@ PyDoc_STRVAR(
         ":return: Total number of messages deserialized so far.\n"
 );
 
-auto PyDeserializerBuffer_get_num_deserialized_log_messages(PyDeserializerBuffer* self
-) -> PyObject* {
+auto PyDeserializerBuffer_get_num_deserialized_log_messages(PyDeserializerBuffer* self)
+        -> PyObject* {
     return PyLong_FromLongLong(static_cast<long long>(self->get_num_deserialized_message()));
 }
 

--- a/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.cpp
+++ b/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.cpp
@@ -51,8 +51,8 @@ namespace {
 class IrUnitHandler {
 public:
     // Methods that implement the `clp::ffi::ir_stream::IrUnitHandlerInterface` interface
-    [[nodiscard]] auto handle_log_event(clp::ffi::KeyValuePairLogEvent&& deserialized_log_event
-    ) -> IRErrorCode {
+    [[nodiscard]] auto handle_log_event(clp::ffi::KeyValuePairLogEvent&& deserialized_log_event)
+            -> IRErrorCode {
         log_event.emplace(std::move(deserialized_log_event));
         return IRErrorCode::IRErrorCode_Success;
     }
@@ -240,11 +240,9 @@ PyDoc_STRVAR(
         " must be strings, including keys inside any sub-dictionaries.\n"
         ":type dictionary: dict[str, Any]\n"
 );
-CLP_FFI_PY_METHOD auto PyKeyValuePairLogEvent_init(
-        PyKeyValuePairLogEvent* self,
-        PyObject* args,
-        PyObject* keywords
-) -> int;
+CLP_FFI_PY_METHOD auto
+PyKeyValuePairLogEvent_init(PyKeyValuePairLogEvent* self, PyObject* args, PyObject* keywords)
+        -> int;
 
 /**
  * Callback of `PyKeyValuePairLogEvent`'s `to_dict` method.
@@ -310,8 +308,8 @@ PyType_Spec PyKeyValuePairLogEvent_type_spec{
  * @return The converted key-value log event of the given dictionary on success.
  * @return std::nullopt on failure with the relevant Python exception and error set.
  */
-[[nodiscard]] auto convert_py_dict_to_key_value_pair_log_event(PyDictObject* py_dict
-) -> std::optional<clp::ffi::KeyValuePairLogEvent>;
+[[nodiscard]] auto convert_py_dict_to_key_value_pair_log_event(PyDictObject* py_dict)
+        -> std::optional<clp::ffi::KeyValuePairLogEvent>;
 
 /**
  * Serializes the given node id value pairs into a Python dictionary object.
@@ -351,11 +349,9 @@ PyType_Spec PyKeyValuePairLogEvent_type_spec{
  */
 [[nodiscard]] auto decode_as_encoded_text_ast(Value const& val) -> std::optional<std::string>;
 
-CLP_FFI_PY_METHOD auto PyKeyValuePairLogEvent_init(
-        PyKeyValuePairLogEvent* self,
-        PyObject* args,
-        PyObject* keywords
-) -> int {
+CLP_FFI_PY_METHOD auto
+PyKeyValuePairLogEvent_init(PyKeyValuePairLogEvent* self, PyObject* args, PyObject* keywords)
+        -> int {
     static char keyword_dictionary[]{"dictionary"};
     static char* keyword_table[]{static_cast<char*>(keyword_dictionary), nullptr};
 
@@ -399,8 +395,8 @@ CLP_FFI_PY_METHOD auto PyKeyValuePairLogEvent_dealloc(PyKeyValuePairLogEvent* se
     Py_TYPE(self)->tp_free(py_reinterpret_cast<PyObject>(self));
 }
 
-auto convert_py_dict_to_key_value_pair_log_event(PyDictObject* py_dict
-) -> std::optional<clp::ffi::KeyValuePairLogEvent> {
+auto convert_py_dict_to_key_value_pair_log_event(PyDictObject* py_dict)
+        -> std::optional<clp::ffi::KeyValuePairLogEvent> {
     PyObjectPtr<PyBytesObject> const serialized_msgpack_byte_sequence{
             py_utils_serialize_dict_to_msgpack(py_dict)
     };
@@ -679,8 +675,8 @@ auto PyKeyValuePairLogEvent::init(clp::ffi::KeyValuePairLogEvent kv_pair_log_eve
     }
 }
 
-auto PyKeyValuePairLogEvent::create(clp::ffi::KeyValuePairLogEvent kv_log_event
-) -> PyKeyValuePairLogEvent* {
+auto PyKeyValuePairLogEvent::create(clp::ffi::KeyValuePairLogEvent kv_log_event)
+        -> PyKeyValuePairLogEvent* {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
     PyKeyValuePairLogEvent* self{PyObject_New(PyKeyValuePairLogEvent, get_py_type())};
     if (nullptr == self) {

--- a/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.hpp
+++ b/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.hpp
@@ -71,8 +71,8 @@ public:
      * given kv log event.
      * @return nullptr on failure with the relevant Python exception and error set.
      */
-    [[nodiscard]] static auto create(clp::ffi::KeyValuePairLogEvent kv_log_event
-    ) -> PyKeyValuePairLogEvent*;
+    [[nodiscard]] static auto create(clp::ffi::KeyValuePairLogEvent kv_log_event)
+            -> PyKeyValuePairLogEvent*;
 
     /**
      * Gets the `PyTypeObject` that represents `PyKeyValuePair`'s Python type. This type is

--- a/src/clp_ffi_py/ir/native/PyMetadata.hpp
+++ b/src/clp_ffi_py/ir/native/PyMetadata.hpp
@@ -40,8 +40,8 @@ public:
      * @return true on success.
      * @return false on failure with the relevant Python exception and error set.
      */
-    [[nodiscard]] auto
-    init(nlohmann::json const& metadata, bool is_four_byte_encoding = true) -> bool;
+    [[nodiscard]] auto init(nlohmann::json const& metadata, bool is_four_byte_encoding = true)
+            -> bool;
 
     /**
      * Releases the memory allocated for underlying metadata field and the reference hold for the

--- a/src/clp_ffi_py/ir/native/PyQuery.cpp
+++ b/src/clp_ffi_py/ir/native/PyQuery.cpp
@@ -1,4 +1,3 @@
-
 #include <wrapped_facade_headers/Python.hpp>  // Must be included before any other header files
 
 #include "PyQuery.hpp"

--- a/src/clp_ffi_py/ir/native/PySerializer.cpp
+++ b/src/clp_ffi_py/ir/native/PySerializer.cpp
@@ -42,8 +42,8 @@ PyDoc_STRVAR(
         " it to `output_stream`. Defaults to 64 KiB.\n"
         ":type buffer_size_limit: int\n"
 );
-CLP_FFI_PY_METHOD auto
-PySerializer_init(PySerializer* self, PyObject* args, PyObject* keywords) -> int;
+CLP_FFI_PY_METHOD auto PySerializer_init(PySerializer* self, PyObject* args, PyObject* keywords)
+        -> int;
 
 /**
  * Callback of `PySerializer`'s `serialize_msgpack` method.
@@ -64,10 +64,9 @@ PyDoc_STRVAR(
         ":raise RuntimeError: If `msgpack_map` couldn't be unpacked or serialization into the IR"
         " stream failed.\n"
 );
-CLP_FFI_PY_METHOD auto PySerializer_serialize_log_event_from_msgpack_map(
-        PySerializer* self,
-        PyObject* msgpack_map
-) -> PyObject*;
+CLP_FFI_PY_METHOD auto
+PySerializer_serialize_log_event_from_msgpack_map(PySerializer* self, PyObject* msgpack_map)
+        -> PyObject*;
 
 /**
  * Callback of `PySerializer`'s `get_num_bytes_serialized` method.
@@ -140,8 +139,8 @@ PyDoc_STRVAR(
         ":param exc_value: The value of the exception that caused the exit. Unused.\n"
         ":param exc_traceable: The traceback. Unused.\n"
 );
-CLP_FFI_PY_METHOD auto
-PySerializer_exit(PySerializer* self, PyObject* args, PyObject* keywords) -> PyObject*;
+CLP_FFI_PY_METHOD auto PySerializer_exit(PySerializer* self, PyObject* args, PyObject* keywords)
+        -> PyObject*;
 
 /**
  * Callback of `PySerializer`'s deallocator.
@@ -206,8 +205,8 @@ PyType_Spec PySerializer_type_spec{
         static_cast<PyType_Slot*>(PySerializer_slots)
 };
 
-CLP_FFI_PY_METHOD auto
-PySerializer_init(PySerializer* self, PyObject* args, PyObject* keywords) -> int {
+CLP_FFI_PY_METHOD auto PySerializer_init(PySerializer* self, PyObject* args, PyObject* keywords)
+        -> int {
     static char keyword_output_stream[]{"output_stream"};
     static char keyword_buffer_size_limit[]{"buffer_size_limit"};
     static char* keyword_table[]{
@@ -286,10 +285,9 @@ PySerializer_init(PySerializer* self, PyObject* args, PyObject* keywords) -> int
     return 0;
 }
 
-CLP_FFI_PY_METHOD auto PySerializer_serialize_log_event_from_msgpack_map(
-        PySerializer* self,
-        PyObject* msgpack_map
-) -> PyObject* {
+CLP_FFI_PY_METHOD auto
+PySerializer_serialize_log_event_from_msgpack_map(PySerializer* self, PyObject* msgpack_map)
+        -> PyObject* {
     if (false == static_cast<bool>(PyBytes_Check(msgpack_map))) {
         PyErr_SetString(
                 PyExc_TypeError,
@@ -334,8 +332,8 @@ CLP_FFI_PY_METHOD auto PySerializer_enter(PySerializer* self) -> PyObject* {
     return py_reinterpret_cast<PyObject>(self);
 }
 
-CLP_FFI_PY_METHOD auto
-PySerializer_exit(PySerializer* self, PyObject* args, PyObject* keywords) -> PyObject* {
+CLP_FFI_PY_METHOD auto PySerializer_exit(PySerializer* self, PyObject* args, PyObject* keywords)
+        -> PyObject* {
     static char keyword_exc_type[]{"exc_type"};
     static char keyword_exc_value[]{"exc_value"};
     static char keyword_traceback[]{"traceback"};
@@ -426,8 +424,8 @@ auto PySerializer::assert_is_not_closed() const -> bool {
     return true;
 }
 
-auto PySerializer::serialize_log_event_from_msgpack_map(std::span<char const> msgpack_byte_sequence
-) -> std::optional<Py_ssize_t> {
+auto PySerializer::serialize_log_event_from_msgpack_map(std::span<char const> msgpack_byte_sequence)
+        -> std::optional<Py_ssize_t> {
     if (false == assert_is_not_closed()) {
         return std::nullopt;
     }
@@ -529,8 +527,8 @@ auto PySerializer::write_ir_buf_to_output_stream() -> bool {
     return true;
 }
 
-auto PySerializer::write_to_output_stream(PySerializer::BufferView buf
-) -> std::optional<Py_ssize_t> {
+auto PySerializer::write_to_output_stream(PySerializer::BufferView buf)
+        -> std::optional<Py_ssize_t> {
     if (buf.empty()) {
         return 0;
     }

--- a/src/clp_ffi_py/ir/native/Query.hpp
+++ b/src/clp_ffi_py/ir/native/Query.hpp
@@ -26,7 +26,7 @@ public:
      */
     WildcardQuery(std::string wildcard_query, bool case_sensitive)
             : m_wildcard_query(std::move(wildcard_query)),
-              m_case_sensitive(case_sensitive) {};
+              m_case_sensitive(case_sensitive) {}
 
     [[nodiscard]] auto get_wildcard_query() const -> std::string const& { return m_wildcard_query; }
 
@@ -69,7 +69,7 @@ public:
     explicit Query()
             : m_lower_bound_ts{cTimestampMin},
               m_upper_bound_ts{cTimestampMax},
-              m_search_termination_ts{cTimestampMax} {};
+              m_search_termination_ts{cTimestampMax} {}
 
     /**
      * Constructs a new query object with the given timestamp range with an empty wildcard list.

--- a/src/clp_ffi_py/ir/native/deserialization_methods.cpp
+++ b/src/clp_ffi_py/ir/native/deserialization_methods.cpp
@@ -59,10 +59,9 @@ concept TerminateHandlerSignature = requires(TerminateHandler handler) {
  * @param nullptr if the IR stream is incomplete not allowed, with the relevant Python exceptions
  * and error set.
  */
-[[nodiscard]] auto handle_incomplete_ir_error(
-        PyDeserializerBuffer* deserializer_buffer,
-        bool allow_incomplete_stream
-) -> std::optional<PyObject*> {
+[[nodiscard]] auto
+handle_incomplete_ir_error(PyDeserializerBuffer* deserializer_buffer, bool allow_incomplete_stream)
+        -> std::optional<PyObject*> {
     if (deserializer_buffer->try_read()) {
         return std::nullopt;
     }

--- a/src/clp_ffi_py/utils.cpp
+++ b/src/clp_ffi_py/utils.cpp
@@ -66,8 +66,8 @@ auto get_py_bool(bool is_true) -> PyObject* {
     Py_RETURN_FALSE;
 }
 
-auto unpack_msgpack(std::span<char const> msgpack_byte_sequence
-) -> outcome_v2::std_result<msgpack::object_handle, std::string> {
+auto unpack_msgpack(std::span<char const> msgpack_byte_sequence)
+        -> outcome_v2::std_result<msgpack::object_handle, std::string> {
     msgpack::object_handle handle;
     try {
         msgpack::unpack(handle, msgpack_byte_sequence.data(), msgpack_byte_sequence.size());

--- a/src/clp_ffi_py/utils.hpp
+++ b/src/clp_ffi_py/utils.hpp
@@ -26,8 +26,8 @@ namespace clp_ffi_py {
  * @return true on success.
  * @return false on failure with the relevant Python exception and error set.
  */
-[[nodiscard]] auto
-add_python_type(PyTypeObject* new_type, char const* type_name, PyObject* module) -> bool;
+[[nodiscard]] auto add_python_type(PyTypeObject* new_type, char const* type_name, PyObject* module)
+        -> bool;
 
 /**
  * Parses a Python string into std::string.
@@ -47,8 +47,8 @@ add_python_type(PyTypeObject* new_type, char const* type_name, PyObject* module)
  * @return true on success.
  * @return false on failure with the relevant Python exception and error set.
  */
-[[nodiscard]] auto
-parse_py_string_as_string_view(PyObject* py_string, std::string_view& view) -> bool;
+[[nodiscard]] auto parse_py_string_as_string_view(PyObject* py_string, std::string_view& view)
+        -> bool;
 
 /**
  * Gets the Python True/False object from a given `bool` value/expression.
@@ -75,8 +75,8 @@ template <clp::IntegerType IntType>
  * @return A result containing the unpacked msgpack object handle on success or an error string
  * indicating the unpack failure (forwarded from the thrown `msgpack::unpack_error`).
  */
-[[nodiscard]] auto unpack_msgpack(std::span<char const> msgpack_byte_sequence
-) -> outcome_v2::std_result<msgpack::object_handle, std::string>;
+[[nodiscard]] auto unpack_msgpack(std::span<char const> msgpack_byte_sequence)
+        -> outcome_v2::std_result<msgpack::object_handle, std::string>;
 
 /*
  * Handles a `clp::TraceableException` by setting a Python exception accordingly.
@@ -94,8 +94,8 @@ template <typename T>
  * @param sv
  * @return The underlying C-string of the given constexpr string view.
  */
-[[nodiscard]] consteval auto get_c_str_from_constexpr_string_view(std::string_view const& sv
-) -> char const*;
+[[nodiscard]] consteval auto get_c_str_from_constexpr_string_view(std::string_view const& sv)
+        -> char const*;
 
 template <clp::IntegerType IntType>
 auto parse_py_int(PyObject* py_int, IntType& val) -> bool {


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR updates yscope-dev-utils to the latest commit so that clang-format v19 config can be used. It also updates clang-format version to v19 in the linter dependency to format C++ code using the latest clang-format pypi release.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure workflows all passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Dependencies**
	- Updated `clang-format` dependency version from `~=18.1` to `>=19.1.6`

- **Code Formatting**
	- Reformatted method signatures across multiple files for improved readability
	- Corrected constructor syntax in several header files

- **New Features**
	- Added comprehensive `PyQuery` class with search query handling capabilities

- **Chores**
	- Updated subproject commit in `tools/yscope-dev-utils`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->