### PR TITLE
refactor: Fix clang-tidy warnings in `PyDeserializer`.

### DIFF
--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -115,6 +115,8 @@ tasks:
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/api_decoration.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/error_messages.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ExceptionFFI.hpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyDeserializer.cpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyDeserializer.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyKeyValuePairLogEvent.cpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyKeyValuePairLogEvent.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PySerializer.cpp"

--- a/src/clp_ffi_py/ir/native/PyDeserializer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializer.cpp
@@ -72,7 +72,7 @@ CLP_FFI_PY_METHOD auto PyDeserializer_deserialize_log_event(PyDeserializer* self
  */
 CLP_FFI_PY_METHOD auto PyDeserializer_dealloc(PyDeserializer* self) -> void;
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+// NOLINTNEXTLINE(*-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables)
 PyMethodDef PyDeserializer_method_table[]{
         {"deserialize_log_event",
          py_c_function_cast(PyDeserializer_deserialize_log_event),
@@ -82,7 +82,8 @@ PyMethodDef PyDeserializer_method_table[]{
         {nullptr}
 };
 
-// NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-pro-type-*-cast)
+// NOLINTBEGIN(cppcoreguidelines-pro-type-*-cast)
+// NOLINTNEXTLINE(*-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables)
 PyType_Slot PyDeserializer_slots[]{
         {Py_tp_alloc, reinterpret_cast<void*>(PyType_GenericAlloc)},
         {Py_tp_dealloc, reinterpret_cast<void*>(PyDeserializer_dealloc)},
@@ -92,11 +93,12 @@ PyType_Slot PyDeserializer_slots[]{
         {Py_tp_doc, const_cast<void*>(static_cast<void const*>(cPyDeserializerDoc))},
         {0, nullptr}
 };
-// NOLINTEND(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-pro-type-*-cast)
+// NOLINTEND(cppcoreguidelines-pro-type-*-cast)
 
 /**
  * `PyDeserializer`'s Python type specifications.
  */
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyType_Spec PyDeserializer_type_spec{
         "clp_ffi_py.ir.native.Deserializer",
         sizeof(PyDeserializer),
@@ -197,7 +199,7 @@ auto PyDeserializer::init(
         if (deserializer_result.has_error()) {
             PyErr_Format(
                     PyExc_RuntimeError,
-                    cDeserializerCreateErrorFormatStr.data(),
+                    get_c_str_from_constexpr_string_view(cDeserializerCreateErrorFormatStr),
                     deserializer_result.error().message().c_str()
             );
             return false;
@@ -232,7 +234,9 @@ auto PyDeserializer::deserialize_log_event() -> PyObject* {
                 if (std::errc::result_out_of_range != err) {
                     PyErr_Format(
                             PyExc_RuntimeError,
-                            cDeserializerDeserializeNextIrUnitErrorFormatStr.data(),
+                            get_c_str_from_constexpr_string_view(
+                                    cDeserializerDeserializeNextIrUnitErrorFormatStr
+                            ),
                             err.message().c_str()
                     );
                     return nullptr;

--- a/src/clp_ffi_py/ir/native/PyDeserializer.hpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializer.hpp
@@ -4,7 +4,6 @@
 #include <wrapped_facade_headers/Python.hpp>  // Must be included before any other header files
 
 #include <functional>
-#include <system_error>
 #include <utility>
 
 #include <clp/ffi/ir_stream/decoding_methods.hpp>


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This is one of the PR series trying to implement #96.
This PR fixes all clang-tidy warnings in `PyDeserializer`.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure the linting workflow passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated linting configuration to include new source files for static code analysis
	- Refined error handling in PyDeserializer implementation
	- Removed unnecessary system error header from PyDeserializer

- **Documentation**
	- Updated NOLINT directives and associated comments for improved code analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->