### PR TITLE
refactor: Fix clang-tidy warnings in `DeserializerBufferReader`.

### DIFF
--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -115,6 +115,8 @@ tasks:
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/api_decoration.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/error_messages.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ExceptionFFI.hpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/DeserializerBufferReader.cpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/DeserializerBufferReader.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyDeserializer.cpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyDeserializer.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyKeyValuePairLogEvent.cpp"

--- a/src/clp_ffi_py/ir/native/DeserializerBufferReader.cpp
+++ b/src/clp_ffi_py/ir/native/DeserializerBufferReader.cpp
@@ -51,7 +51,7 @@ auto DeserializerBufferReader::try_read(char* buf, size_t num_bytes_to_read, siz
         auto const bytes_to_copy{
                 buffered_bytes_view.subspan(0, std::min(buffered_bytes_view.size(), dst_buf.size()))
         };
-        std::copy(bytes_to_copy.begin(), bytes_to_copy.end(), dst_buf.begin());
+        std::ranges::copy(bytes_to_copy.begin(), bytes_to_copy.end(), dst_buf.begin());
 
         // Commit read
         auto const num_bytes_copied{bytes_to_copy.size()};


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This is one of the PR series trying to implement #96.
This PR fixes all clang-tidy warnings in `DeserializerBufferReader`.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure the linting workflow passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Extended static code analysis to include two new source files in the `DeserializerBufferReader` module
	- Updated data copying method in `try_read` method using modern C++ ranges-based copy algorithm

<!-- end of auto-generated comment: release notes by coderabbit.ai -->