### PR TITLE
refactor: Fix clang-tidy warnings in `PyDeserializerBuffer` to align with the latest C++ coding guideline.

### DIFF
--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -119,6 +119,8 @@ tasks:
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/DeserializerBufferReader.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyDeserializer.cpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyDeserializer.hpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyDeserializerBuffer.cpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyDeserializerBuffer.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyKeyValuePairLogEvent.cpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyKeyValuePairLogEvent.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PySerializer.cpp"

--- a/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializerBuffer.cpp
@@ -3,9 +3,16 @@
 #include "PyDeserializerBuffer.hpp"
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <random>
 #include <span>
+#include <type_traits>
+#include <vector>
 
+#include <clp/type_utils.hpp>
+
+#include <clp_ffi_py/api_decoration.hpp>
 #include <clp_ffi_py/error_messages.hpp>
 #include <clp_ffi_py/ir/native/error_messages.hpp>
 #include <clp_ffi_py/PyObjectCast.hpp>
@@ -14,7 +21,6 @@
 
 namespace clp_ffi_py::ir::native {
 namespace {
-extern "C" {
 /**
  * Callback of PyDeserializerBuffer `__init__` method:
  * __init__(self, input_stream: IO[bytes], initial_buffer_capacity: int = 4096)
@@ -27,8 +33,138 @@ extern "C" {
  * @return 0 on success.
  * @return -1 on failure with the relevant Python exception and error set.
  */
-auto PyDeserializerBuffer_init(PyDeserializerBuffer* self, PyObject* args, PyObject* keywords)
-        -> int {
+CLP_FFI_PY_METHOD auto
+PyDeserializerBuffer_init(PyDeserializerBuffer* self, PyObject* args, PyObject* keywords) -> int;
+
+/**
+ * Callback of PyDeserializerBuffer deallocator.
+ * @param self
+ */
+CLP_FFI_PY_METHOD auto PyDeserializerBuffer_dealloc(PyDeserializerBuffer* self) -> void;
+
+/**
+ * Callback of Python buffer protocol's `getbuffer` operation.
+ * @param self
+ * @param view
+ * @param flags
+ * @return 0 on success.
+ * @return -1 on failure with the relevant Python exception and error set.
+ */
+CLP_FFI_PY_METHOD auto
+PyDeserializerBuffer_getbuffer(PyDeserializerBuffer* self, Py_buffer* view, int flags) -> int;
+
+/**
+ * Callback of Python buffer protocol's `releasebuffer` operation.
+ * This callback doesn't do anything, but it is set intentionally to avoid unexpected behaviour.
+ * @param self (unused).
+ * @param view (unused).
+ */
+CLP_FFI_PY_METHOD auto PyDeserializerBuffer_releasebuffer(
+        PyDeserializerBuffer* Py_UNUSED(self),
+        Py_buffer* Py_UNUSED(view)
+) -> void;
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+PyDoc_STRVAR(
+        cPyDeserializerBufferGetNumDeserializedLogMessages,
+        "get_num_deserialized_log_messages(self)\n"
+        "--\n\n"
+        ":return: Total number of messages deserialized so far.\n"
+);
+CLP_FFI_PY_METHOD auto PyDeserializerBuffer_get_num_deserialized_log_messages(
+        PyDeserializerBuffer* self
+) -> PyObject*;
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+PyDoc_STRVAR(
+        cPyDeserializerBufferTestStreamingDoc,
+        "_test_streaming(self, seed)\n"
+        "--\n\n"
+        "Tests the functionality of the DeserializerBuffer by streaming the entire input stream "
+        "into a Python bytearray. The stepping size from the read buffer is randomly generated, "
+        "initialized by the given seed.\n\n"
+        "Note: this function should only be used for testing purpose.\n\n"
+        ":param seed_obj: Random seed.\n"
+        ":return: The entire input stream stored in a Python bytearray.\n"
+);
+CLP_FFI_PY_METHOD auto
+PyDeserializerBuffer_test_streaming(PyDeserializerBuffer* self, PyObject* seed_obj) -> PyObject*;
+
+// NOLINTNEXTLINE(*-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables)
+PyMethodDef PyDeserializerBuffer_method_table[]{
+        {"get_num_deserialized_log_messages",
+         py_c_function_cast(PyDeserializerBuffer_get_num_deserialized_log_messages),
+         METH_NOARGS,
+         static_cast<char const*>(cPyDeserializerBufferGetNumDeserializedLogMessages)},
+
+        {"_test_streaming",
+         py_c_function_cast(PyDeserializerBuffer_test_streaming),
+         METH_O,
+         static_cast<char const*>(cPyDeserializerBufferTestStreamingDoc)},
+
+        {nullptr}
+};
+
+/**
+ * Declaration of Python buffer protocol.
+ */
+// NOLINTNEXTLINE(*-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables)
+PyBufferProcs PyDeserializerBuffer_as_buffer{
+        .bf_getbuffer = py_getbufferproc_cast(PyDeserializerBuffer_getbuffer),
+        .bf_releasebuffer = py_releasebufferproc_cast(PyDeserializerBuffer_releasebuffer),
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+PyDoc_STRVAR(
+        cPyDeserializerBufferDoc,
+        "This class represents a CLP IR Deserializer Buffer corresponding to a CLP IR stream. "
+        "It buffers serialized CLP IR data read from the input stream, which can be consumed by "
+        "the CLP IR deserialization methods to recover serialized log events. An instance of this "
+        "class is expected to be passed across different calls of CLP IR deserialization methods "
+        "when deserializing from the same IR stream.\n\n"
+        "The signature of `__init__` method is shown as following:\n\n"
+        "__init__(self, input_stream, initial_buffer_capacity=4096)\n\n"
+        "Initializes a DeserializerBuffer object for the given input IR stream.\n\n"
+        ":param input_stream: Input stream that contains serialized CLP IR. It should be an "
+        "instance of type `IO[bytes]` with the method `readinto` supported.\n"
+        ":param initial_buffer_capacity: The initial capacity of the underlying byte buffer.\n"
+);
+
+// NOLINTBEGIN(cppcoreguidelines-pro-type-*-cast)
+// NOLINTNEXTLINE(*-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables)
+PyType_Slot PyDeserializerBuffer_slots[]{
+        {Py_tp_alloc, reinterpret_cast<void*>(PyType_GenericAlloc)},
+        {Py_tp_dealloc, reinterpret_cast<void*>(PyDeserializerBuffer_dealloc)},
+        {Py_tp_new, reinterpret_cast<void*>(PyType_GenericNew)},
+        {Py_tp_init, reinterpret_cast<void*>(PyDeserializerBuffer_init)},
+        {Py_tp_methods, static_cast<void*>(PyDeserializerBuffer_method_table)},
+        {Py_tp_doc, const_cast<void*>(static_cast<void const*>(cPyDeserializerBufferDoc))},
+        {0, nullptr}
+};
+// NOLINTEND(cppcoreguidelines-pro-type-*-cast)
+
+/**
+ * PyDeserializerBuffer Python type specifications.
+ */
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+PyType_Spec PyDeserializerBuffer_type_spec{
+        "clp_ffi_py.ir.native.DeserializerBuffer",
+        sizeof(PyDeserializerBuffer),
+        0,
+        Py_TPFLAGS_DEFAULT,
+        static_cast<PyType_Slot*>(PyDeserializerBuffer_slots)
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+PyDoc_STRVAR(
+        cPyIncompleteStreamErrorDoc,
+        "This exception will be raised if the deserializer buffer cannot read more data from the "
+        "input stream while the deserialization method expects more bytes.\n"
+        "Typically, this error indicates the input stream has been truncated.\n"
+);
+
+CLP_FFI_PY_METHOD auto
+PyDeserializerBuffer_init(PyDeserializerBuffer* self, PyObject* args, PyObject* keywords) -> int {
     static char keyword_input_stream[]{"input_stream"};
     static char keyword_initial_buffer_capacity[]{"initial_buffer_capacity"};
     static char* keyword_table[]{
@@ -78,145 +214,87 @@ auto PyDeserializerBuffer_init(PyDeserializerBuffer* self, PyObject* args, PyObj
     return 0;
 }
 
-/**
- * Callback of PyDeserializerBuffer deallocator.
- * @param self
- */
-auto PyDeserializerBuffer_dealloc(PyDeserializerBuffer* self) -> void {
+CLP_FFI_PY_METHOD auto PyDeserializerBuffer_dealloc(PyDeserializerBuffer* self) -> void {
     self->clean();
     PyObject_Del(self);
 }
 
-/**
- * Callback of Python buffer protocol's `getbuffer` operation.
- * @param self
- * @param view
- * @param flags
- * @return 0 on success.
- * @return -1 on failure with the relevant Python exception and error set.
- */
-auto PyDeserializerBuffer_getbuffer(PyDeserializerBuffer* self, Py_buffer* view, int flags) -> int {
+CLP_FFI_PY_METHOD auto
+PyDeserializerBuffer_getbuffer(PyDeserializerBuffer* self, Py_buffer* view, int flags) -> int {
     return self->py_getbuffer(view, flags);
 }
 
-/**
- * Callback of Python buffer protocol's `releasebuffer` operation.
- * This callback doesn't do anything, but it is set intentionally to avoid unexpected behaviour.
- * @param self (unused).
- * @param view (unused).
- */
-auto PyDeserializerBuffer_releasebuffer(
+CLP_FFI_PY_METHOD auto PyDeserializerBuffer_releasebuffer(
         PyDeserializerBuffer* Py_UNUSED(self),
         Py_buffer* Py_UNUSED(view)
 ) -> void {}
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-PyDoc_STRVAR(
-        cPyDeserializerBufferGetNumDeserializedLogMessages,
-        "get_num_deserialized_log_messages(self)\n"
-        "--\n\n"
-        ":return: Total number of messages deserialized so far.\n"
-);
-
-auto PyDeserializerBuffer_get_num_deserialized_log_messages(PyDeserializerBuffer* self)
-        -> PyObject* {
+CLP_FFI_PY_METHOD auto PyDeserializerBuffer_get_num_deserialized_log_messages(
+        PyDeserializerBuffer* self
+) -> PyObject* {
     return PyLong_FromLongLong(static_cast<long long>(self->get_num_deserialized_message()));
 }
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-PyDoc_STRVAR(
-        cPyDeserializerBufferTestStreamingDoc,
-        "_test_streaming(self, seed)\n"
-        "--\n\n"
-        "Tests the functionality of the DeserializerBuffer by streaming the entire input stream "
-        "into a Python bytearray. The stepping size from the read buffer is randomly generated, "
-        "initialized by the given seed.\n\n"
-        "Note: this function should only be used for testing purpose.\n\n"
-        ":param seed_obj: Random seed.\n"
-        ":return: The entire input stream stored in a Python bytearray.\n"
-);
-
-auto PyDeserializerBuffer_test_streaming(PyDeserializerBuffer* self, PyObject* seed_obj)
-        -> PyObject* {
+CLP_FFI_PY_METHOD auto
+PyDeserializerBuffer_test_streaming(PyDeserializerBuffer* self, PyObject* seed_obj) -> PyObject* {
     unsigned seed{0};
     if (false == parse_py_int<uint32_t>(seed_obj, seed)) {
         return nullptr;
     }
     return self->test_streaming(seed);
 }
+}  // namespace
+
+auto PyDeserializerBuffer::create(PyObject* input_stream, Py_ssize_t buf_capacity)
+        -> PyDeserializerBuffer* {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    PyDeserializerBuffer* self{PyObject_New(PyDeserializerBuffer, get_py_type())};
+    if (nullptr == self) {
+        PyErr_SetString(
+                PyExc_MemoryError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cOutOfMemoryError)
+        );
+        return nullptr;
+    }
+    self->default_init();
+    if (false == self->init(input_stream, buf_capacity)) {
+        return nullptr;
+    }
+    return self;
 }
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-PyMethodDef PyDeserializerBuffer_method_table[]{
-        {"get_num_deserialized_log_messages",
-         py_c_function_cast(PyDeserializerBuffer_get_num_deserialized_log_messages),
-         METH_NOARGS,
-         static_cast<char const*>(cPyDeserializerBufferGetNumDeserializedLogMessages)},
+auto PyDeserializerBuffer::get_py_type() -> PyTypeObject* {
+    return m_py_type.get();
+}
 
-        {"_test_streaming",
-         py_c_function_cast(PyDeserializerBuffer_test_streaming),
-         METH_O,
-         static_cast<char const*>(cPyDeserializerBufferTestStreamingDoc)},
+auto PyDeserializerBuffer::get_py_incomplete_stream_error() -> PyObject* {
+    return m_py_incomplete_stream_error.get();
+}
 
-        {nullptr}
-};
+auto PyDeserializerBuffer::module_level_init(PyObject* py_module) -> bool {
+    static_assert(std::is_trivially_destructible<PyDeserializerBuffer>());
+    auto* py_incomplete_stream_error{PyErr_NewExceptionWithDoc(
+            "clp_ffi_py.native.IncompleteStreamError",
+            static_cast<char const*>(cPyIncompleteStreamErrorDoc),
+            nullptr,
+            nullptr
+    )};
+    m_py_incomplete_stream_error.reset(py_incomplete_stream_error);
+    if (nullptr == py_incomplete_stream_error) {
+        return false;
+    }
+    if (0 > PyModule_AddObject(py_module, "IncompleteStreamError", py_incomplete_stream_error)) {
+        return false;
+    }
 
-/**
- * Declaration of Python buffer protocol.
- */
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-PyBufferProcs PyDeserializerBuffer_as_buffer{
-        .bf_getbuffer = py_getbufferproc_cast(PyDeserializerBuffer_getbuffer),
-        .bf_releasebuffer = py_releasebufferproc_cast(PyDeserializerBuffer_releasebuffer),
-};
-
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-PyDoc_STRVAR(
-        cPyDeserializerBufferDoc,
-        "This class represents a CLP IR Deserializer Buffer corresponding to a CLP IR stream. "
-        "It buffers serialized CLP IR data read from the input stream, which can be consumed by "
-        "the CLP IR deserialization methods to recover serialized log events. An instance of this "
-        "class is expected to be passed across different calls of CLP IR deserialization methods "
-        "when deserializing from the same IR stream.\n\n"
-        "The signature of `__init__` method is shown as following:\n\n"
-        "__init__(self, input_stream, initial_buffer_capacity=4096)\n\n"
-        "Initializes a DeserializerBuffer object for the given input IR stream.\n\n"
-        ":param input_stream: Input stream that contains serialized CLP IR. It should be an "
-        "instance of type `IO[bytes]` with the method `readinto` supported.\n"
-        ":param initial_buffer_capacity: The initial capacity of the underlying byte buffer.\n"
-);
-
-// NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-pro-type-*-cast)
-PyType_Slot PyDeserializerBuffer_slots[]{
-        {Py_tp_alloc, reinterpret_cast<void*>(PyType_GenericAlloc)},
-        {Py_tp_dealloc, reinterpret_cast<void*>(PyDeserializerBuffer_dealloc)},
-        {Py_tp_new, reinterpret_cast<void*>(PyType_GenericNew)},
-        {Py_tp_init, reinterpret_cast<void*>(PyDeserializerBuffer_init)},
-        {Py_tp_methods, static_cast<void*>(PyDeserializerBuffer_method_table)},
-        {Py_tp_doc, const_cast<void*>(static_cast<void const*>(cPyDeserializerBufferDoc))},
-        {0, nullptr}
-};
-// NOLINTEND(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-pro-type-*-cast)
-
-/**
- * PyDeserializerBuffer Python type specifications.
- */
-PyType_Spec PyDeserializerBuffer_type_spec{
-        "clp_ffi_py.ir.native.DeserializerBuffer",
-        sizeof(PyDeserializerBuffer),
-        0,
-        Py_TPFLAGS_DEFAULT,
-        static_cast<PyType_Slot*>(PyDeserializerBuffer_slots)
-};
-
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-PyDoc_STRVAR(
-        cPyIncompleteStreamErrorDoc,
-        "This exception will be raised if the deserializer buffer cannot read more data from the "
-        "input stream while the deserialization method expects more bytes.\n"
-        "Typically, this error indicates the input stream has been truncated.\n"
-);
-}  // namespace
+    auto* type{py_reinterpret_cast<PyTypeObject>(PyType_FromSpec(&PyDeserializerBuffer_type_spec))};
+    m_py_type.reset(type);
+    if (nullptr == type) {
+        return false;
+    }
+    type->tp_as_buffer = &PyDeserializerBuffer_as_buffer;
+    return add_python_type(get_py_type(), "DeserializerBuffer", py_module);
+}
 
 auto PyDeserializerBuffer::init(PyObject* input_stream, Py_ssize_t buf_capacity) -> bool {
     if (0 >= buf_capacity) {
@@ -250,7 +328,7 @@ auto PyDeserializerBuffer::populate_read_buffer(Py_ssize_t& num_bytes_read) -> b
             return false;
         }
         std::span<int8_t> const new_read_buffer{new_buf, static_cast<size_t>(new_capacity)};
-        std::copy(
+        std::ranges::copy(
                 unconsumed_bytes_in_curr_read_buffer.begin(),
                 unconsumed_bytes_in_curr_read_buffer.end(),
                 new_read_buffer.begin()
@@ -259,7 +337,7 @@ auto PyDeserializerBuffer::populate_read_buffer(Py_ssize_t& num_bytes_read) -> b
         m_read_buffer_mem_owner = new_buf;
         m_read_buffer = new_read_buffer;
     } else if (0 < num_unconsumed_bytes) {
-        std::copy(
+        std::ranges::copy(
                 unconsumed_bytes_in_curr_read_buffer.begin(),
                 unconsumed_bytes_in_curr_read_buffer.end(),
                 m_read_buffer.begin()
@@ -375,59 +453,5 @@ auto PyDeserializerBuffer::test_streaming(uint32_t seed) -> PyObject* {
             clp::size_checked_pointer_cast<char>(read_bytes.data()),
             static_cast<Py_ssize_t>(read_bytes.size())
     );
-}
-
-PyObjectStaticPtr<PyTypeObject> PyDeserializerBuffer::m_py_type{nullptr};
-PyObjectStaticPtr<PyObject> PyDeserializerBuffer::m_py_incomplete_stream_error{nullptr};
-
-auto PyDeserializerBuffer::create(PyObject* input_stream, Py_ssize_t buf_capacity)
-        -> PyDeserializerBuffer* {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-    PyDeserializerBuffer* self{PyObject_New(PyDeserializerBuffer, get_py_type())};
-    if (nullptr == self) {
-        PyErr_SetString(
-                PyExc_MemoryError,
-                get_c_str_from_constexpr_string_view(clp_ffi_py::cOutOfMemoryError)
-        );
-        return nullptr;
-    }
-    self->default_init();
-    if (false == self->init(input_stream, buf_capacity)) {
-        return nullptr;
-    }
-    return self;
-}
-
-auto PyDeserializerBuffer::get_py_type() -> PyTypeObject* {
-    return m_py_type.get();
-}
-
-auto PyDeserializerBuffer::get_py_incomplete_stream_error() -> PyObject* {
-    return m_py_incomplete_stream_error.get();
-}
-
-auto PyDeserializerBuffer::module_level_init(PyObject* py_module) -> bool {
-    static_assert(std::is_trivially_destructible<PyDeserializerBuffer>());
-    auto* py_incomplete_stream_error{PyErr_NewExceptionWithDoc(
-            "clp_ffi_py.native.IncompleteStreamError",
-            static_cast<char const*>(cPyIncompleteStreamErrorDoc),
-            nullptr,
-            nullptr
-    )};
-    m_py_incomplete_stream_error.reset(py_incomplete_stream_error);
-    if (nullptr == py_incomplete_stream_error) {
-        return false;
-    }
-    if (0 > PyModule_AddObject(py_module, "IncompleteStreamError", py_incomplete_stream_error)) {
-        return false;
-    }
-
-    auto* type{py_reinterpret_cast<PyTypeObject>(PyType_FromSpec(&PyDeserializerBuffer_type_spec))};
-    m_py_type.reset(type);
-    if (nullptr == type) {
-        return false;
-    }
-    type->tp_as_buffer = &PyDeserializerBuffer_as_buffer;
-    return add_python_type(get_py_type(), "DeserializerBuffer", py_module);
 }
 }  // namespace clp_ffi_py::ir::native

--- a/src/wrapped_facade_headers/Python.hpp
+++ b/src/wrapped_facade_headers/Python.hpp
@@ -17,6 +17,7 @@
 // IWYU pragma: begin_exports
 #include <abstract.h>
 #include <boolobject.h>
+#include <bytearrayobject.h>
 #include <bytesobject.h>
 #include <dictobject.h>
 #include <floatobject.h>
@@ -30,6 +31,7 @@
 #include <objimpl.h>
 #include <pyerrors.h>
 #include <pymacro.h>
+#include <pymem.h>
 #include <pyport.h>
 #include <typeslots.h>
 #include <unicodeobject.h>


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This is one of the PR series trying to implement #96.
This PR fixes all clang-tidy warnings in `PyDeserializerBuffer`. Other than that, it also fixes the following problem:
- Correct the ordering of class member declaration (and fix the implementation ordering accordingly)
- Use API decoration instead of using `extern "C"` block explicitly
- Ensure local helper functions are declared before defined

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure workflows passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced static code analysis coverage for PyDeserializerBuffer source files
	- Added new methods for managing Python deserializer buffer instances

- **Improvements**
	- Refined memory management and object creation for PyDeserializerBuffer
	- Updated Python C API header inclusions for better linting support

- **Technical Updates**
	- Restructured method implementations for PyDeserializerBuffer
	- Added factory methods for controlled object instantiation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->