### PR TITLE
refactor: Reordering class members in `PySerializer`, `PyDeserializer` and `PyKeyValuePairLogEvent` to align with the latest C++ coding guideline.

### DIFF
--- a/src/clp_ffi_py/ir/native/PyDeserializer.cpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializer.cpp
@@ -159,6 +159,16 @@ CLP_FFI_PY_METHOD auto PyDeserializer_dealloc(PyDeserializer* self) -> void {
 }
 }  // namespace
 
+auto PyDeserializer::module_level_init(PyObject* py_module) -> bool {
+    static_assert(std::is_trivially_destructible<PyDeserializer>());
+    auto* type{py_reinterpret_cast<PyTypeObject>(PyType_FromSpec(&PyDeserializer_type_spec))};
+    m_py_type.reset(type);
+    if (nullptr == type) {
+        return false;
+    }
+    return add_python_type(get_py_type(), "Deserializer", py_module);
+}
+
 auto PyDeserializer::init(
         PyObject* input_stream,
         Py_ssize_t buffer_capacity,
@@ -271,16 +281,6 @@ auto PyDeserializer::deserialize_log_event() -> PyObject* {
     }
 
     Py_RETURN_NONE;
-}
-
-auto PyDeserializer::module_level_init(PyObject* py_module) -> bool {
-    static_assert(std::is_trivially_destructible<PyDeserializer>());
-    auto* type{py_reinterpret_cast<PyTypeObject>(PyType_FromSpec(&PyDeserializer_type_spec))};
-    m_py_type.reset(type);
-    if (nullptr == type) {
-        return false;
-    }
-    return add_python_type(get_py_type(), "Deserializer", py_module);
 }
 
 auto PyDeserializer::handle_log_event(clp::ffi::KeyValuePairLogEvent&& log_event) -> IRErrorCode {

--- a/src/clp_ffi_py/ir/native/PyDeserializer.hpp
+++ b/src/clp_ffi_py/ir/native/PyDeserializer.hpp
@@ -30,6 +30,24 @@ public:
      */
     static constexpr Py_ssize_t cDefaultBufferCapacity{65'536};
 
+    /**
+     * Gets the `PyTypeObject` that represents `PyDeserializer`'s Python type. This type is
+     * dynamically created and initialized during the execution of
+     * `PyDeserializer::module_level_init`.
+     * @return Python type object associated with `PyDeserializer`.
+     */
+    [[nodiscard]] static auto get_py_type() -> PyTypeObject* { return m_py_type.get(); }
+
+    /**
+     * Creates and initializes `PyDeserializer` as a Python type, and then incorporates this
+     * type as a Python object into the py_module module.
+     * @param py_module This is the Python module where the initialized `PyDeserializer` will be
+     * incorporated.
+     * @return true on success.
+     * @return false on failure with the relevant Python exception and error set.
+     */
+    [[nodiscard]] static auto module_level_init(PyObject* py_module) -> bool;
+
     // Delete default constructor to disable direct instantiation.
     PyDeserializer() = delete;
 
@@ -90,24 +108,6 @@ public:
      * @return nullptr on failure with the relevant Python exception and error set.
      */
     [[nodiscard]] auto deserialize_log_event() -> PyObject*;
-
-    /**
-     * Gets the `PyTypeObject` that represents `PyDeserializer`'s Python type. This type is
-     * dynamically created and initialized during the execution of
-     * `PyDeserializer::module_level_init`.
-     * @return Python type object associated with `PyDeserializer`.
-     */
-    [[nodiscard]] static auto get_py_type() -> PyTypeObject* { return m_py_type.get(); }
-
-    /**
-     * Creates and initializes `PyDeserializer` as a Python type, and then incorporates this
-     * type as a Python object into the py_module module.
-     * @param py_module This is the Python module where the initialized `PyDeserializer` will be
-     * incorporated.
-     * @return true on success.
-     * @return false on failure with the relevant Python exception and error set.
-     */
-    [[nodiscard]] static auto module_level_init(PyObject* py_module) -> bool;
 
 private:
     /**
@@ -181,6 +181,8 @@ private:
 
     using Deserializer = clp::ffi::ir_stream::Deserializer<IrUnitHandler>;
 
+    static inline PyObjectStaticPtr<PyTypeObject> m_py_type{nullptr};
+
     // Methods
     /**
      * Implements `IrUnitHandler::EndOfStreamHandle`.
@@ -244,8 +246,6 @@ private:
     gsl::owner<Deserializer*> m_deserializer;
     gsl::owner<clp::ffi::KeyValuePairLogEvent*> m_deserialized_log_event;
     // NOLINTEND(cppcoreguidelines-owning-memory)
-
-    static inline PyObjectStaticPtr<PyTypeObject> m_py_type{nullptr};
 };
 }  // namespace clp_ffi_py::ir::native
 

--- a/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.cpp
+++ b/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.cpp
@@ -652,6 +652,35 @@ auto decode_as_encoded_text_ast(Value const& val) -> std::optional<std::string> 
 }
 }  // namespace
 
+auto PyKeyValuePairLogEvent::create(clp::ffi::KeyValuePairLogEvent kv_log_event)
+        -> PyKeyValuePairLogEvent* {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+    PyKeyValuePairLogEvent* self{PyObject_New(PyKeyValuePairLogEvent, get_py_type())};
+    if (nullptr == self) {
+        return nullptr;
+    }
+    self->default_init();
+    if (false == self->init(std::move(kv_log_event))) {
+        return nullptr;
+    }
+    return self;
+}
+
+auto PyKeyValuePairLogEvent::get_py_type() -> PyTypeObject* {
+    return m_py_type.get();
+}
+
+auto PyKeyValuePairLogEvent::module_level_init(PyObject* py_module) -> bool {
+    static_assert(std::is_trivially_destructible<PyKeyValuePairLogEvent>());
+    auto* type{py_reinterpret_cast<PyTypeObject>(PyType_FromSpec(&PyKeyValuePairLogEvent_type_spec))
+    };
+    m_py_type.reset(type);
+    if (nullptr == type) {
+        return false;
+    }
+    return add_python_type(get_py_type(), "KeyValuePairLogEvent", py_module);
+}
+
 auto PyKeyValuePairLogEvent::init(clp::ffi::KeyValuePairLogEvent kv_pair_log_event) -> bool {
     m_kv_pair_log_event
             = new (std::nothrow) clp::ffi::KeyValuePairLogEvent{std::move(kv_pair_log_event)};
@@ -687,34 +716,5 @@ auto PyKeyValuePairLogEvent::init(clp::ffi::KeyValuePairLogEvent kv_pair_log_eve
         handle_traceable_exception(ex);
         return nullptr;
     }
-}
-
-auto PyKeyValuePairLogEvent::create(clp::ffi::KeyValuePairLogEvent kv_log_event)
-        -> PyKeyValuePairLogEvent* {
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-    PyKeyValuePairLogEvent* self{PyObject_New(PyKeyValuePairLogEvent, get_py_type())};
-    if (nullptr == self) {
-        return nullptr;
-    }
-    self->default_init();
-    if (false == self->init(std::move(kv_log_event))) {
-        return nullptr;
-    }
-    return self;
-}
-
-auto PyKeyValuePairLogEvent::get_py_type() -> PyTypeObject* {
-    return m_py_type.get();
-}
-
-auto PyKeyValuePairLogEvent::module_level_init(PyObject* py_module) -> bool {
-    static_assert(std::is_trivially_destructible<PyKeyValuePairLogEvent>());
-    auto* type{py_reinterpret_cast<PyTypeObject>(PyType_FromSpec(&PyKeyValuePairLogEvent_type_spec))
-    };
-    m_py_type.reset(type);
-    if (nullptr == type) {
-        return false;
-    }
-    return add_python_type(get_py_type(), "KeyValuePairLogEvent", py_module);
 }
 }  // namespace clp_ffi_py::ir::native

--- a/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.hpp
+++ b/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.hpp
@@ -15,6 +15,33 @@ namespace clp_ffi_py::ir::native {
  */
 class PyKeyValuePairLogEvent {
 public:
+    /**
+     * CPython-level factory function.
+     * @param kv_log_event
+     * @return a new reference of a `PyKeyValuePairLogEvent` object that is initialized with the
+     * given kv log event.
+     * @return nullptr on failure with the relevant Python exception and error set.
+     */
+    [[nodiscard]] static auto create(clp::ffi::KeyValuePairLogEvent kv_log_event)
+            -> PyKeyValuePairLogEvent*;
+
+    /**
+     * Gets the `PyTypeObject` that represents `PyKeyValuePair`'s Python type. This type is
+     * dynamically created and initialized during the execution of `module_level_init`.
+     * @return Python type object associated with `PyKeyValuePairLogEvent`.
+     */
+    [[nodiscard]] static auto get_py_type() -> PyTypeObject*;
+
+    /**
+     * Creates and initializes `PyKeyValuePairLogEvent` as a Python type, and then incorporates this
+     * type as a Python object into the py_module module.
+     * @param py_module The Python module where the initialized `PyKeyValuePairLogEvent` will be
+     * incorporated.
+     * @return true on success.
+     * @return false on failure with the relevant Python exception and error set.
+     */
+    [[nodiscard]] static auto module_level_init(PyObject* py_module) -> bool;
+
     // Delete default constructor to disable direct instantiation.
     PyKeyValuePairLogEvent() = delete;
 
@@ -64,40 +91,13 @@ public:
      */
     [[nodiscard]] auto to_dict() -> PyDictObject*;
 
-    /**
-     * CPython-level factory function.
-     * @param kv_log_event
-     * @return a new reference of a `PyKeyValuePairLogEvent` object that is initialized with the
-     * given kv log event.
-     * @return nullptr on failure with the relevant Python exception and error set.
-     */
-    [[nodiscard]] static auto create(clp::ffi::KeyValuePairLogEvent kv_log_event)
-            -> PyKeyValuePairLogEvent*;
-
-    /**
-     * Gets the `PyTypeObject` that represents `PyKeyValuePair`'s Python type. This type is
-     * dynamically created and initialized during the execution of `module_level_init`.
-     * @return Python type object associated with `PyKeyValuePairLogEvent`.
-     */
-    [[nodiscard]] static auto get_py_type() -> PyTypeObject*;
-
-    /**
-     * Creates and initializes `PyKeyValuePairLogEvent` as a Python type, and then incorporates this
-     * type as a Python object into the py_module module.
-     * @param py_module The Python module where the initialized `PyKeyValuePairLogEvent` will be
-     * incorporated.
-     * @return true on success.
-     * @return false on failure with the relevant Python exception and error set.
-     */
-    [[nodiscard]] static auto module_level_init(PyObject* py_module) -> bool;
-
 private:
-    PyObject_HEAD;
+    static inline PyObjectStaticPtr<PyTypeObject> m_py_type{nullptr};
 
+    // Variables
+    PyObject_HEAD;
     // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     gsl::owner<clp::ffi::KeyValuePairLogEvent*> m_kv_pair_log_event;
-
-    static inline PyObjectStaticPtr<PyTypeObject> m_py_type{nullptr};
 };
 }  // namespace clp_ffi_py::ir::native
 

--- a/src/clp_ffi_py/ir/native/PySerializer.cpp
+++ b/src/clp_ffi_py/ir/native/PySerializer.cpp
@@ -395,6 +395,16 @@ CLP_FFI_PY_METHOD auto PySerializer_dealloc(PySerializer* self) -> void {
 }
 }  // namespace
 
+auto PySerializer::module_level_init(PyObject* py_module) -> bool {
+    static_assert(std::is_trivially_destructible<PySerializer>());
+    auto* type{py_reinterpret_cast<PyTypeObject>(PyType_FromSpec(&PySerializer_type_spec))};
+    m_py_type.reset(type);
+    if (nullptr == type) {
+        return false;
+    }
+    return add_python_type(get_py_type(), "Serializer", py_module);
+}
+
 auto PySerializer::init(
         PyObject* output_stream,
         PySerializer::ClpIrSerializer serializer,
@@ -500,16 +510,6 @@ auto PySerializer::close() -> bool {
 
     close_serializer();
     return true;
-}
-
-auto PySerializer::module_level_init(PyObject* py_module) -> bool {
-    static_assert(std::is_trivially_destructible<PySerializer>());
-    auto* type{py_reinterpret_cast<PyTypeObject>(PyType_FromSpec(&PySerializer_type_spec))};
-    m_py_type.reset(type);
-    if (nullptr == type) {
-        return false;
-    }
-    return add_python_type(get_py_type(), "Serializer", py_module);
 }
 
 auto PySerializer::write_ir_buf_to_output_stream() -> bool {


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR refactors `PySerializer`, `PyDeserializer`, and `PyKeyValuePairLogEvent` to fix the class member ordering:
- Ensure static members are declared before non-static ones
- Correct the definition ordering accordingly

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure all workflows passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Python integration for log event processing classes
	- Added type management methods for serialization and deserialization components
	- Introduced new initialization methods for key-value pair log events

- **Improvements**
	- Refined type initialization and management in Python environment
	- Added default buffer size limit for serialization
	- Improved error handling and type checking mechanisms

- **Technical Updates**
	- Updated internal methods for Python type registration
	- Restructured class initialization processes for better compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->