### PR TITLE
refactor: Fix clang-tidy warnings in `PyQuery` to align with the latest C++ coding guideline.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,7 @@ find_package(
 )
 
 set(CLP_FFI_PY_LIB_IR "native")
-python_add_library(
-    ${CLP_FFI_PY_LIB_IR}
-    MODULE
-    WITH_SOABI
-)
+python_add_library(${CLP_FFI_PY_LIB_IR} MODULE WITH_SOABI)
 
 target_compile_features(${CLP_FFI_PY_LIB_IR} PRIVATE cxx_std_20)
 

--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -123,6 +123,8 @@ tasks:
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyDeserializerBuffer.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyKeyValuePairLogEvent.cpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyKeyValuePairLogEvent.hpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyQuery.cpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyQuery.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PySerializer.cpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PySerializer.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/modules"

--- a/src/clp_ffi_py/ir/native/PyQuery.cpp
+++ b/src/clp_ffi_py/ir/native/PyQuery.cpp
@@ -3,222 +3,75 @@
 #include "PyQuery.hpp"
 
 #include <new>
+#include <string_view>
+#include <type_traits>
+#include <vector>
 
+#include <clp/ir/types.hpp>
 #include <clp/string_utils/string_utils.hpp>
 
+#include <clp_ffi_py/api_decoration.hpp>
 #include <clp_ffi_py/error_messages.hpp>
-#include <clp_ffi_py/ir/native/LogEvent.hpp>
+#include <clp_ffi_py/ExceptionFFI.hpp>
 #include <clp_ffi_py/ir/native/PyLogEvent.hpp>
 #include <clp_ffi_py/ir/native/Query.hpp>
 #include <clp_ffi_py/PyObjectCast.hpp>
+#include <clp_ffi_py/PyObjectUtils.hpp>
 #include <clp_ffi_py/utils.hpp>
 
 namespace clp_ffi_py::ir::native {
 namespace {
 /**
- * Deserializes the wildcard queries from a list of Python wildcard queries into a WildcardQuery
- * std::vector. If there is no wildcard queries given, the given py_wildcard_queries will be set to
- * Py_None.
- * @param py_wildcard_queries A Python list that contains Python wildcard queries. Each element
- * inside this list should be an instance of WildcardQuery defined in clp_ffi_py Python module.
- * @param wildcard_queries The output std::vector that contains cleaned wildcard queries from the
- * input. If py_wildcard_queries is Py_None, wildcard_queries will be set to empty.
- * @return true on success.
- * @return false on failure with the relevant Python exception and error set.
- */
-auto deserialize_wildcard_queries(
-        PyObject* py_wildcard_queries,
-        std::vector<WildcardQuery>& wildcard_queries
-) -> bool {
-    wildcard_queries.clear();
-    if (Py_None == py_wildcard_queries) {
-        return true;
-    }
-
-    if (false == static_cast<bool>(PyObject_TypeCheck(py_wildcard_queries, &PyList_Type))) {
-        PyErr_SetString(
-                PyExc_TypeError,
-                get_c_str_from_constexpr_string_view(clp_ffi_py::cPyTypeError)
-        );
-        return false;
-    }
-
-    auto const wildcard_queries_size{PyList_Size(py_wildcard_queries)};
-    wildcard_queries.reserve(wildcard_queries_size);
-    for (Py_ssize_t idx{0}; idx < wildcard_queries_size; ++idx) {
-        auto* wildcard_query{PyList_GetItem(py_wildcard_queries, idx)};
-        if (1 != PyObject_IsInstance(wildcard_query, PyQuery::get_py_wildcard_query_type())) {
-            PyErr_SetString(
-                    PyExc_TypeError,
-                    get_c_str_from_constexpr_string_view(clp_ffi_py::cPyTypeError)
-            );
-            return false;
-        }
-        auto* wildcard_query_py_str{PyObject_GetAttrString(wildcard_query, "wildcard_query")};
-        if (nullptr == wildcard_query_py_str) {
-            return false;
-        }
-        auto* case_sensitive_py_bool{PyObject_GetAttrString(wildcard_query, "case_sensitive")};
-        if (nullptr == case_sensitive_py_bool) {
-            return false;
-        }
-        std::string_view wildcard_query_view;
-        if (false == parse_py_string_as_string_view(wildcard_query_py_str, wildcard_query_view)) {
-            return false;
-        }
-        int const is_case_sensitive{PyObject_IsTrue(case_sensitive_py_bool)};
-        if (-1 == is_case_sensitive && nullptr != PyErr_Occurred()) {
-            return false;
-        }
-        wildcard_queries.emplace_back(
-                clp::string_utils::clean_up_wildcard_search_string(wildcard_query_view),
-                static_cast<bool>(is_case_sensitive)
-        );
-    }
-    return true;
-}
-
-/**
- * Serializes the std::vector of WildcardQuery into a Python list. Serves as a helper function to
- * serialize the underlying wildcard queries of the PyQuery object.
- * @param wildcard_queries A std::vector of WildcardQuery.
- * @return The Python list that consists of Python wildcard query objects.
- * @return Py_None if the wildcard_queries are empty.
- */
-auto serialize_wildcard_queries(std::vector<WildcardQuery> const& wildcard_queries) -> PyObject* {
-    Py_ssize_t const wildcard_queries_size{static_cast<Py_ssize_t>(wildcard_queries.size())};
-    if (0 == wildcard_queries_size) {
-        Py_RETURN_NONE;
-    }
-
-    auto* py_wildcard_queries{PyList_New(wildcard_queries_size)};
-    if (nullptr == py_wildcard_queries) {
-        return nullptr;
-    }
-
-    // In case of failure, we only need to decrement the reference for the Python list. CPython will
-    // decrement the reference count of all the objects it contains.
-    Py_ssize_t idx{0};
-    for (auto const& wildcard_query : wildcard_queries) {
-        PyObjectPtr<PyObject> const wildcard_py_str_ptr{
-                PyUnicode_FromString(wildcard_query.get_wildcard_query().c_str())
-        };
-        auto* wildcard_py_str{wildcard_py_str_ptr.get()};
-        if (nullptr == wildcard_py_str) {
-            Py_DECREF(py_wildcard_queries);
-            return nullptr;
-        }
-        PyObjectPtr<PyObject> const is_case_sensitive{get_py_bool(wildcard_query.is_case_sensitive()
-        )};
-        PyObject* py_wildcard_query{PyObject_CallFunction(
-                PyQuery::get_py_full_string_wildcard_query_type(),
-                "OO",
-                wildcard_py_str,
-                is_case_sensitive.get()
-        )};
-        if (nullptr == py_wildcard_query) {
-            Py_DECREF(py_wildcard_queries);
-            return nullptr;
-        }
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        PyList_SET_ITEM(py_wildcard_queries, idx, py_wildcard_query);
-        ++idx;
-    }
-    return py_wildcard_queries;
-}
-
-extern "C" {
-/**
- * Callback of PyQuery `__init__` method:
- * __init__(
- *      self,
- *      search_time_lower_bound=Query.default_search_time_lower_bound(),
- *      search_time_upper_bound=Query.default_search_time_upper_bound(),
- *      wildcard_queries=None,
- *      search_time_termination_margin=
- *              Query.default_search_time_termination_margin()
- * )
- * Keyword argument parsing is supported.
- * Assumes `self` is uninitialized and will allocate the underlying memory. If `self` is already
- * initialized this will result in memory leaks.
- * @param self
- * @param args
- * @param keywords
- * @return 0 on success.
- * @return -1 on failure with the relevant Python exception and error set.
- */
-auto PyQuery_init(PyQuery* self, PyObject* args, PyObject* keywords) -> int {
-    static char keyword_search_time_lower_bound[]{"search_time_lower_bound"};
-    static char keyword_search_time_upper_bound[]{"search_time_upper_bound"};
-    static char keyword_wildcard_queries[]{"wildcard_queries"};
-    static char keyword_search_time_termination_margin[]{"search_time_termination_margin"};
-    static char* keyword_table[]{
-            static_cast<char*>(keyword_search_time_lower_bound),
-            static_cast<char*>(keyword_search_time_upper_bound),
-            static_cast<char*>(keyword_wildcard_queries),
-            static_cast<char*>(keyword_search_time_termination_margin),
-            nullptr
-    };
-
-    // If the argument parsing fails, `self` will be deallocated. We must reset all pointers to
-    // nullptr in advance, otherwise the deallocator might trigger a segmentation fault.
-    self->default_init();
-
-    auto search_time_lower_bound{Query::cTimestampMin};
-    auto search_time_upper_bound{Query::cTimestampMax};
-    auto* py_wildcard_queries{Py_None};
-    auto search_time_termination_margin{Query::cDefaultSearchTimeTerminationMargin};
-
-    if (false
-        == static_cast<bool>(PyArg_ParseTupleAndKeywords(
-                args,
-                keywords,
-                "|LLOL",
-                static_cast<char**>(keyword_table),
-                &search_time_lower_bound,
-                &search_time_upper_bound,
-                &py_wildcard_queries,
-                &search_time_termination_margin
-        )))
-    {
-        return -1;
-    }
-
-    std::vector<WildcardQuery> wildcard_queries;
-    if (false == deserialize_wildcard_queries(py_wildcard_queries, wildcard_queries)) {
-        return -1;
-    }
-
-    if (false
-        == self->init(
-                search_time_lower_bound,
-                search_time_upper_bound,
-                wildcard_queries,
-                search_time_termination_margin
-        ))
-    {
-        return -1;
-    }
-    return 0;
-}
-
-/**
- * Callback of PyQuery deallocator.
- * @param self
- */
-auto PyQuery_dealloc(PyQuery* self) -> void {
-    self->clean();
-    PyObject_Del(self);
-}
-
-/**
  * Constant keys used to serialize/deserialize PyQuery objects through `__getstate__` and
  * `__setstate__` methods.
  */
-constexpr char const* const cStateSearchTimeLowerBound = "search_time_lower_bound";
-constexpr char const* const cStateSearchTimeUpperBound = "search_time_upper_bound";
-constexpr char const* const cStateWildcardQueries = "wildcard_queries";
-constexpr char const* const cStateSearchTimeTerminationMargin = "search_time_termination_margin";
+constexpr std::string_view cStateSearchTimeLowerBound{"search_time_lower_bound"};
+constexpr std::string_view cStateSearchTimeUpperBound{"search_time_upper_bound"};
+constexpr std::string_view cStateWildcardQueries{"wildcard_queries"};
+constexpr std::string_view cStateSearchTimeTerminationMargin{"search_time_termination_margin"};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+PyDoc_STRVAR(
+        cPyQueryDoc,
+        "This class represents a search query, utilized for filtering log events in a CLP IR "
+        "stream. The query could include a list of wildcard queries aimed at identifying certain "
+        "log messages, and a timestamp range with a lower and upper bound. This class provides an "
+        "interface to set up a search query, as well as methods to validate whether the query can "
+        "be matched by a log event. Note that an empty wildcard query list will match any log "
+        "within the range.\n\n"
+        "By default, the wildcard query list is empty and the timestamp range is set to include "
+        "all the valid Unix epoch timestamps. To filter certain log messages, use customized "
+        "wildcard queries to initialize the wildcard query list. For more details, check the "
+        "documentation of the class `WildcardQuery`.\n\n"
+        "NOTE: When searching an IR stream with a query, ideally, the search would terminate once "
+        "the current log event's timestamp exceeds the upper bound of the query's time range. "
+        "However, the timestamps in the IR stream might not be monotonically increasing; they can "
+        "be locally disordered due to thread contention. To safely stop searching, the "
+        "deserializer needs to ensure that the current timestamp in the IR stream exceeds the "
+        "query's upper bound timestamp by a reasonable margin. This margin can be specified during "
+        "the initialization. This margin is set to a default value specified by the static method "
+        "`default_search_time_termination_margin()`. Users can customized this margin accordingly, "
+        "for example, the margin can be set to 0 if the CLP IR stream is generated from a "
+        "single-threaded program execution.\n\n"
+        "The signature of `__init__` method is shown as following:\n\n"
+        "__init__(self, search_time_lower_bound=Query.default_search_time_lower_bound(), "
+        "search_time_upper_bound=Query.default_search_time_upper_bound(), "
+        "wildcard_queries=None,search_time_termination_margin=Query.default_search_time_"
+        "termination_margin())\n\n"
+        "Initializes a Query object using the given inputs.\n\n"
+        ":param search_time_lower_bound: Start of search time range (inclusive).\n"
+        ":param search_time_upper_bound: End of search time range (inclusive).\n"
+        ":param wildcard_queries: A list of wildcard queries.\n"
+        ":param search_time_termination_margin: The margin used to determine the search "
+        "termination timestamp.\n"
+);
+CLP_FFI_PY_METHOD auto PyQuery_init(PyQuery* self, PyObject* args, PyObject* keywords) -> int;
+
+/**
+ * Callback of `PyQuery` deallocator.
+ * @param self
+ */
+CLP_FFI_PY_METHOD auto PyQuery_dealloc(PyQuery* self) -> void;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -228,31 +81,7 @@ PyDoc_STRVAR(
         "Serializes the Query object (should be called by the Python pickle module).\n\n"
         ":return: Serialized query in a Python dictionary.\n"
 );
-
-/**
- * Callback of PyQuery `__getstate__` method.
- * @param self
- * @return Python dictionary that contains the serialized object.
- * @return nullptr on failure with the relevant Python exception and error set.
- */
-auto PyQuery_getstate(PyQuery* self) -> PyObject* {
-    auto* query{self->get_query()};
-    auto* py_wildcard_queries{serialize_wildcard_queries(query->get_wildcard_queries())};
-    if (nullptr == py_wildcard_queries) {
-        return nullptr;
-    }
-    return Py_BuildValue(
-            "{sLsLsOsL}",
-            cStateSearchTimeLowerBound,
-            query->get_lower_bound_ts(),
-            cStateSearchTimeUpperBound,
-            query->get_upper_bound_ts(),
-            cStateWildcardQueries,
-            py_wildcard_queries,
-            cStateSearchTimeTerminationMargin,
-            query->get_search_time_termination_margin()
-    );
-}
+CLP_FFI_PY_METHOD auto PyQuery_getstate(PyQuery* self) -> PyObject*;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -267,114 +96,7 @@ PyDoc_STRVAR(
         "to be the valid output of the `__getstate__` method.\n"
         ":return: None\n"
 );
-
-/**
- * Callback of PyQuery `__setstate__` method.
- * Note: should only be used by the Python pickle module.
- * Assumes `self` is uninitialized and will allocate the underlying memory. If `self` is already
- * initialized this will result in memory leaks.
- * @param self
- * @param state Python dictionary that contains the serialized object info.
- * @return Py_None on success
- * @return nullptr on failure with the relevant Python exception and error set.
- */
-auto PyQuery_setstate(PyQuery* self, PyObject* state) -> PyObject* {
-    self->default_init();
-
-    if (false == static_cast<bool>(PyDict_CheckExact(state))) {
-        PyErr_SetString(
-                PyExc_ValueError,
-                get_c_str_from_constexpr_string_view(clp_ffi_py::cSetstateInputError)
-        );
-        return nullptr;
-    }
-
-    auto* search_time_lower_bound_obj{PyDict_GetItemString(state, cStateSearchTimeLowerBound)};
-    if (nullptr == search_time_lower_bound_obj) {
-        PyErr_Format(
-                PyExc_KeyError,
-                get_c_str_from_constexpr_string_view(clp_ffi_py::cSetstateKeyErrorTemplate),
-                cStateSearchTimeLowerBound
-        );
-        return nullptr;
-    }
-    clp::ir::epoch_time_ms_t search_time_lower_bound{0};
-    if (false
-        == parse_py_int<clp::ir::epoch_time_ms_t>(
-                search_time_lower_bound_obj,
-                search_time_lower_bound
-        ))
-    {
-        return nullptr;
-    }
-
-    auto* search_time_upper_bound_obj{PyDict_GetItemString(state, cStateSearchTimeUpperBound)};
-    if (nullptr == search_time_upper_bound_obj) {
-        PyErr_Format(
-                PyExc_KeyError,
-                get_c_str_from_constexpr_string_view(clp_ffi_py::cSetstateKeyErrorTemplate),
-                cStateSearchTimeUpperBound
-        );
-        return nullptr;
-    }
-    clp::ir::epoch_time_ms_t search_time_upper_bound{0};
-    if (false
-        == parse_py_int<clp::ir::epoch_time_ms_t>(
-                search_time_upper_bound_obj,
-                search_time_upper_bound
-        ))
-    {
-        return nullptr;
-    }
-
-    auto* py_wildcard_queries{PyDict_GetItemString(state, cStateWildcardQueries)};
-    if (nullptr == py_wildcard_queries) {
-        PyErr_Format(
-                PyExc_KeyError,
-                get_c_str_from_constexpr_string_view(clp_ffi_py::cSetstateKeyErrorTemplate),
-                cStateWildcardQueries
-        );
-        return nullptr;
-    }
-    std::vector<WildcardQuery> wildcard_queries;
-    if (false == deserialize_wildcard_queries(py_wildcard_queries, wildcard_queries)) {
-        return nullptr;
-    }
-
-    auto* search_time_termination_margin_obj{
-            PyDict_GetItemString(state, cStateSearchTimeTerminationMargin)
-    };
-    if (nullptr == search_time_termination_margin_obj) {
-        PyErr_Format(
-                PyExc_KeyError,
-                get_c_str_from_constexpr_string_view(clp_ffi_py::cSetstateKeyErrorTemplate),
-                cStateSearchTimeTerminationMargin
-        );
-        return nullptr;
-    }
-    clp::ir::epoch_time_ms_t search_time_termination_margin{0};
-    if (false
-        == parse_py_int<clp::ir::epoch_time_ms_t>(
-                search_time_termination_margin_obj,
-                search_time_termination_margin
-        ))
-    {
-        return nullptr;
-    }
-
-    if (false
-        == self->init(
-                search_time_lower_bound,
-                search_time_upper_bound,
-                wildcard_queries,
-                search_time_termination_margin
-        ))
-    {
-        return nullptr;
-    }
-
-    Py_RETURN_NONE;
-}
+CLP_FFI_PY_METHOD auto PyQuery_setstate(PyQuery* self, PyObject* state) -> PyObject*;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -388,15 +110,7 @@ PyDoc_STRVAR(
         "     least one match.\n"
         "   - False otherwise.\n"
 );
-
-auto PyQuery_match_log_event(PyQuery* self, PyObject* log_event) -> PyObject* {
-    if (false == static_cast<bool>(PyObject_TypeCheck(log_event, PyLogEvent::get_py_type()))) {
-        PyErr_SetString(PyExc_TypeError, get_c_str_from_constexpr_string_view(cPyTypeError));
-        return nullptr;
-    }
-    auto* py_log_event{py_reinterpret_cast<PyLogEvent>(log_event)};
-    return get_py_bool(self->get_query()->matches(*py_log_event->get_log_event()));
-}
+CLP_FFI_PY_METHOD auto PyQuery_match_log_event(PyQuery* self, PyObject* log_event) -> PyObject*;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -405,10 +119,7 @@ PyDoc_STRVAR(
         "--\n\n"
         ":return: The search time lower bound.\n"
 );
-
-auto PyQuery_get_search_time_lower_bound(PyQuery* self) -> PyObject* {
-    return PyLong_FromLongLong(self->get_query()->get_lower_bound_ts());
-}
+CLP_FFI_PY_METHOD auto PyQuery_get_search_time_lower_bound(PyQuery* self) -> PyObject*;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -417,10 +128,7 @@ PyDoc_STRVAR(
         "--\n\n"
         ":return: The search time upper bound.\n"
 );
-
-auto PyQuery_get_search_time_upper_bound(PyQuery* self) -> PyObject* {
-    return PyLong_FromLongLong(self->get_query()->get_upper_bound_ts());
-}
+CLP_FFI_PY_METHOD auto PyQuery_get_search_time_upper_bound(PyQuery* self) -> PyObject*;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -431,10 +139,7 @@ PyDoc_STRVAR(
         "objects.\n"
         ":return: None if the wildcard queries are empty.\n"
 );
-
-auto PyQuery_get_wildcard_queries(PyQuery* self) -> PyObject* {
-    return serialize_wildcard_queries(self->get_query()->get_wildcard_queries());
-}
+CLP_FFI_PY_METHOD auto PyQuery_get_wildcard_queries(PyQuery* self) -> PyObject*;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -443,10 +148,7 @@ PyDoc_STRVAR(
         "--\n\n"
         ":return: The search time termination margin.\n"
 );
-
-auto PyQuery_get_search_time_termination_margin(PyQuery* self) -> PyObject* {
-    return PyLong_FromLongLong(self->get_query()->get_search_time_termination_margin());
-}
+CLP_FFI_PY_METHOD auto PyQuery_get_search_time_termination_margin(PyQuery* self) -> PyObject*;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -455,10 +157,8 @@ PyDoc_STRVAR(
         "--\n\n"
         ":return: The minimum valid timestamp from Unix epoch time.\n"
 );
-
-auto PyQuery_default_search_time_lower_bound(PyObject* Py_UNUSED(self)) -> PyObject* {
-    return PyLong_FromLongLong(Query::cTimestampMin);
-}
+CLP_FFI_PY_METHOD auto PyQuery_default_search_time_lower_bound(PyObject* Py_UNUSED(self))
+        -> PyObject*;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -467,10 +167,8 @@ PyDoc_STRVAR(
         "--\n\n"
         ":return: The maximum valid timestamp from Unix epoch time.\n"
 );
-
-auto PyQuery_default_search_time_upper_bound(PyObject* Py_UNUSED(self)) -> PyObject* {
-    return PyLong_FromLongLong(Query::cTimestampMax);
-}
+CLP_FFI_PY_METHOD auto PyQuery_default_search_time_upper_bound(PyObject* Py_UNUSED(self))
+        -> PyObject*;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
 PyDoc_STRVAR(
@@ -479,31 +177,24 @@ PyDoc_STRVAR(
         "--\n\n"
         ":return: The default search termination margin as Unix epoch time.\n"
 );
-
-auto PyQuery_default_search_time_termination_margin(PyObject* Py_UNUSED(self)) -> PyObject* {
-    return PyLong_FromLongLong(Query::cDefaultSearchTimeTerminationMargin);
-}
+CLP_FFI_PY_METHOD auto PyQuery_default_search_time_termination_margin(PyObject* Py_UNUSED(self))
+        -> PyObject*;
 
 /**
- * Callback of PyQuery `__str__` method.
+ * Callback of `PyQuery`'s `__str__` method.
  * @param self
- * @return Python string representation of the serialzed PyQuery object.
+ * @return Python string representation of the serialized `PyQuery` object.
  */
-auto PyQuery_str(PyQuery* self) -> PyObject* {
-    return PyObject_Str(PyQuery_getstate(self));
-}
+CLP_FFI_PY_METHOD auto PyQuery_str(PyQuery* self) -> PyObject*;
 
 /**
- * Callback of PyQuery `__repr__` method.
+ * Callback of `PyQuery`'s `__repr__` method.
  * @param self
- * @return __repr__ of the serialzied PyQuery object.
+ * @return __repr__ of the serialized `PyQuery` object.
  */
-auto PyQuery_repr(PyQuery* self) -> PyObject* {
-    return PyObject_Repr(PyQuery_getstate(self));
-}
-}
+CLP_FFI_PY_METHOD auto PyQuery_repr(PyQuery* self) -> PyObject*;
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+// NOLINTNEXTLINE(*-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables)
 PyMethodDef PyQuery_method_table[]{
         {"match_log_event",
          py_c_function_cast(PyQuery_match_log_event),
@@ -558,43 +249,8 @@ PyMethodDef PyQuery_method_table[]{
         {nullptr}
 };
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
-PyDoc_STRVAR(
-        cPyQueryDoc,
-        "This class represents a search query, utilized for filtering log events in a CLP IR "
-        "stream. The query could include a list of wildcard queries aimed at identifying certain "
-        "log messages, and a timestamp range with a lower and upper bound. This class provides an "
-        "interface to set up a search query, as well as methods to validate whether the query can "
-        "be matched by a log event. Note that an empty wildcard query list will match any log "
-        "within the range.\n\n"
-        "By default, the wildcard query list is empty and the timestamp range is set to include "
-        "all the valid Unix epoch timestamps. To filter certain log messages, use customized "
-        "wildcard queries to initialize the wildcard query list. For more details, check the "
-        "documentation of the class `WildcardQuery`.\n\n"
-        "NOTE: When searching an IR stream with a query, ideally, the search would terminate once "
-        "the current log event's timestamp exceeds the upper bound of the query's time range. "
-        "However, the timestamps in the IR stream might not be monotonically increasing; they can "
-        "be locally disordered due to thread contention. To safely stop searching, the "
-        "deserializer needs to ensure that the current timestamp in the IR stream exceeds the "
-        "query's upper bound timestamp by a reasonable margin. This margin can be specified during "
-        "the initialization. This margin is set to a default value specified by the static method "
-        "`default_search_time_termination_margin()`. Users can customized this margin accordingly, "
-        "for example, the margin can be set to 0 if the CLP IR stream is generated from a "
-        "single-threaded program execution.\n\n"
-        "The signature of `__init__` method is shown as following:\n\n"
-        "__init__(self, search_time_lower_bound=Query.default_search_time_lower_bound(), "
-        "search_time_upper_bound=Query.default_search_time_upper_bound(), "
-        "wildcard_queries=None,search_time_termination_margin=Query.default_search_time_"
-        "termination_margin())\n\n"
-        "Initializes a Query object using the given inputs.\n\n"
-        ":param search_time_lower_bound: Start of search time range (inclusive).\n"
-        ":param search_time_upper_bound: End of search time range (inclusive).\n"
-        ":param wildcard_queries: A list of wildcard queries.\n"
-        ":param search_time_termination_margin: The margin used to determine the search "
-        "termination timestamp.\n"
-);
-
-// NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-pro-type-*-cast)
+// NOLINTBEGIN(cppcoreguidelines-pro-type-*-cast)
+// NOLINTNEXTLINE(*-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables)
 PyType_Slot PyQuery_slots[]{
         {Py_tp_alloc, reinterpret_cast<void*>(PyType_GenericAlloc)},
         {Py_tp_dealloc, reinterpret_cast<void*>(PyQuery_dealloc)},
@@ -606,11 +262,12 @@ PyType_Slot PyQuery_slots[]{
         {Py_tp_doc, const_cast<void*>(static_cast<void const*>(cPyQueryDoc))},
         {0, nullptr}
 };
-// NOLINTEND(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-pro-type-*-cast)
+// NOLINTEND(cppcoreguidelines-pro-type-*-cast)
 
 /**
- * PyQuery Python type specifications.
+ * `PyQuery` Python type specifications.
  */
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyType_Spec PyQuery_type_spec{
         "clp_ffi_py.ir.native.Query",
         sizeof(Query),
@@ -618,39 +275,360 @@ PyType_Spec PyQuery_type_spec{
         Py_TPFLAGS_DEFAULT,
         static_cast<PyType_Slot*>(PyQuery_slots)
 };
-}  // namespace
 
-auto PyQuery::init(
-        clp::ir::epoch_time_ms_t search_time_lower_bound,
-        clp::ir::epoch_time_ms_t search_time_upper_bound,
-        std::vector<WildcardQuery> const& wildcard_queries,
-        clp::ir::epoch_time_ms_t search_time_termination_margin
+/**
+ * Deserializes the wildcard queries from a list of Python wildcard queries into a WildcardQuery
+ * std::vector. If there is no wildcard queries given, the given py_wildcard_queries will be set to
+ * Py_None.
+ * @param py_wildcard_queries A Python list that contains Python wildcard queries. Each element
+ * inside this list should be an instance of WildcardQuery defined in clp_ffi_py Python module.
+ * @param wildcard_queries The output std::vector that contains cleaned wildcard queries from the
+ * input. If py_wildcard_queries is Py_None, wildcard_queries will be set to empty.
+ * @return true on success.
+ * @return false on failure with the relevant Python exception and error set.
+ */
+auto deserialize_wildcard_queries(
+        PyObject* py_wildcard_queries,
+        std::vector<WildcardQuery>& wildcard_queries
+) -> bool;
+
+/**
+ * Serializes the std::vector of WildcardQuery into a Python list. Serves as a helper function to
+ * serialize the underlying wildcard queries of the PyQuery object.
+ * @param wildcard_queries A std::vector of WildcardQuery.
+ * @return The Python list that consists of Python wildcard query objects.
+ * @return Py_None if the wildcard_queries are empty.
+ */
+auto serialize_wildcard_queries(std::vector<WildcardQuery> const& wildcard_queries) -> PyObject*;
+
+CLP_FFI_PY_METHOD auto PyQuery_init(PyQuery* self, PyObject* args, PyObject* keywords) -> int {
+    static char keyword_search_time_lower_bound[]{"search_time_lower_bound"};
+    static char keyword_search_time_upper_bound[]{"search_time_upper_bound"};
+    static char keyword_wildcard_queries[]{"wildcard_queries"};
+    static char keyword_search_time_termination_margin[]{"search_time_termination_margin"};
+    static char* keyword_table[]{
+            static_cast<char*>(keyword_search_time_lower_bound),
+            static_cast<char*>(keyword_search_time_upper_bound),
+            static_cast<char*>(keyword_wildcard_queries),
+            static_cast<char*>(keyword_search_time_termination_margin),
+            nullptr
+    };
+
+    // If the argument parsing fails, `self` will be deallocated. We must reset all pointers to
+    // nullptr in advance, otherwise the deallocator might trigger a segmentation fault.
+    self->default_init();
+
+    auto search_time_lower_bound{Query::cTimestampMin};
+    auto search_time_upper_bound{Query::cTimestampMax};
+    auto* py_wildcard_queries{Py_None};
+    auto search_time_termination_margin{Query::cDefaultSearchTimeTerminationMargin};
+
+    if (false
+        == static_cast<bool>(PyArg_ParseTupleAndKeywords(
+                args,
+                keywords,
+                "|LLOL",
+                static_cast<char**>(keyword_table),
+                &search_time_lower_bound,
+                &search_time_upper_bound,
+                &py_wildcard_queries,
+                &search_time_termination_margin
+        )))
+    {
+        return -1;
+    }
+
+    std::vector<WildcardQuery> wildcard_queries;
+    if (false == deserialize_wildcard_queries(py_wildcard_queries, wildcard_queries)) {
+        return -1;
+    }
+
+    if (false
+        == self->init(
+                search_time_lower_bound,
+                search_time_upper_bound,
+                wildcard_queries,
+                search_time_termination_margin
+        ))
+    {
+        return -1;
+    }
+    return 0;
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_dealloc(PyQuery* self) -> void {
+    self->clean();
+    PyObject_Del(self);
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_getstate(PyQuery* self) -> PyObject* {
+    auto* query{self->get_query()};
+    auto* py_wildcard_queries{serialize_wildcard_queries(query->get_wildcard_queries())};
+    if (nullptr == py_wildcard_queries) {
+        return nullptr;
+    }
+    return Py_BuildValue(
+            "{sLsLsOsL}",
+            get_c_str_from_constexpr_string_view(cStateSearchTimeLowerBound),
+            query->get_lower_bound_ts(),
+            get_c_str_from_constexpr_string_view(cStateSearchTimeUpperBound),
+            query->get_upper_bound_ts(),
+            get_c_str_from_constexpr_string_view(cStateWildcardQueries),
+            py_wildcard_queries,
+            get_c_str_from_constexpr_string_view(cStateSearchTimeTerminationMargin),
+            query->get_search_time_termination_margin()
+    );
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_setstate(PyQuery* self, PyObject* state) -> PyObject* {
+    self->default_init();
+
+    if (false == static_cast<bool>(PyDict_CheckExact(state))) {
+        PyErr_SetString(
+                PyExc_ValueError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cSetstateInputError)
+        );
+        return nullptr;
+    }
+
+    auto* search_time_lower_bound_obj{PyDict_GetItemString(
+            state,
+            get_c_str_from_constexpr_string_view(cStateSearchTimeLowerBound)
+    )};
+    if (nullptr == search_time_lower_bound_obj) {
+        PyErr_Format(
+                PyExc_KeyError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cSetstateKeyErrorTemplate),
+                cStateSearchTimeLowerBound
+        );
+        return nullptr;
+    }
+    clp::ir::epoch_time_ms_t search_time_lower_bound{0};
+    if (false
+        == parse_py_int<clp::ir::epoch_time_ms_t>(
+                search_time_lower_bound_obj,
+                search_time_lower_bound
+        ))
+    {
+        return nullptr;
+    }
+
+    auto* search_time_upper_bound_obj{PyDict_GetItemString(
+            state,
+            get_c_str_from_constexpr_string_view(cStateSearchTimeUpperBound)
+    )};
+    if (nullptr == search_time_upper_bound_obj) {
+        PyErr_Format(
+                PyExc_KeyError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cSetstateKeyErrorTemplate),
+                cStateSearchTimeUpperBound
+        );
+        return nullptr;
+    }
+    clp::ir::epoch_time_ms_t search_time_upper_bound{0};
+    if (false
+        == parse_py_int<clp::ir::epoch_time_ms_t>(
+                search_time_upper_bound_obj,
+                search_time_upper_bound
+        ))
+    {
+        return nullptr;
+    }
+
+    auto* py_wildcard_queries{
+            PyDict_GetItemString(state, get_c_str_from_constexpr_string_view(cStateWildcardQueries))
+    };
+    if (nullptr == py_wildcard_queries) {
+        PyErr_Format(
+                PyExc_KeyError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cSetstateKeyErrorTemplate),
+                cStateWildcardQueries
+        );
+        return nullptr;
+    }
+    std::vector<WildcardQuery> wildcard_queries;
+    if (false == deserialize_wildcard_queries(py_wildcard_queries, wildcard_queries)) {
+        return nullptr;
+    }
+
+    auto* search_time_termination_margin_obj{PyDict_GetItemString(
+            state,
+            get_c_str_from_constexpr_string_view(cStateSearchTimeTerminationMargin)
+    )};
+    if (nullptr == search_time_termination_margin_obj) {
+        PyErr_Format(
+                PyExc_KeyError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cSetstateKeyErrorTemplate),
+                cStateSearchTimeTerminationMargin
+        );
+        return nullptr;
+    }
+    clp::ir::epoch_time_ms_t search_time_termination_margin{0};
+    if (false
+        == parse_py_int<clp::ir::epoch_time_ms_t>(
+                search_time_termination_margin_obj,
+                search_time_termination_margin
+        ))
+    {
+        return nullptr;
+    }
+
+    if (false
+        == self->init(
+                search_time_lower_bound,
+                search_time_upper_bound,
+                wildcard_queries,
+                search_time_termination_margin
+        ))
+    {
+        return nullptr;
+    }
+
+    Py_RETURN_NONE;
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_match_log_event(PyQuery* self, PyObject* log_event) -> PyObject* {
+    if (false == static_cast<bool>(PyObject_TypeCheck(log_event, PyLogEvent::get_py_type()))) {
+        PyErr_SetString(PyExc_TypeError, get_c_str_from_constexpr_string_view(cPyTypeError));
+        return nullptr;
+    }
+    auto* py_log_event{py_reinterpret_cast<PyLogEvent>(log_event)};
+    return get_py_bool(self->get_query()->matches(*py_log_event->get_log_event()));
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_get_search_time_lower_bound(PyQuery* self) -> PyObject* {
+    return PyLong_FromLongLong(self->get_query()->get_lower_bound_ts());
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_get_search_time_upper_bound(PyQuery* self) -> PyObject* {
+    return PyLong_FromLongLong(self->get_query()->get_upper_bound_ts());
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_get_wildcard_queries(PyQuery* self) -> PyObject* {
+    return serialize_wildcard_queries(self->get_query()->get_wildcard_queries());
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_get_search_time_termination_margin(PyQuery* self) -> PyObject* {
+    return PyLong_FromLongLong(self->get_query()->get_search_time_termination_margin());
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_default_search_time_lower_bound(PyObject* Py_UNUSED(self))
+        -> PyObject* {
+    return PyLong_FromLongLong(Query::cTimestampMin);
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_default_search_time_upper_bound(PyObject* Py_UNUSED(self))
+        -> PyObject* {
+    return PyLong_FromLongLong(Query::cTimestampMax);
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_default_search_time_termination_margin(PyObject* Py_UNUSED(self))
+        -> PyObject* {
+    return PyLong_FromLongLong(Query::cDefaultSearchTimeTerminationMargin);
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_str(PyQuery* self) -> PyObject* {
+    return PyObject_Str(PyQuery_getstate(self));
+}
+
+CLP_FFI_PY_METHOD auto PyQuery_repr(PyQuery* self) -> PyObject* {
+    return PyObject_Repr(PyQuery_getstate(self));
+}
+
+auto deserialize_wildcard_queries(
+        PyObject* py_wildcard_queries,
+        std::vector<WildcardQuery>& wildcard_queries
 ) -> bool {
-    try {
-        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-        m_query = new (std::nothrow)
-                Query(search_time_lower_bound,
-                      search_time_upper_bound,
-                      wildcard_queries,
-                      search_time_termination_margin);
-        if (nullptr == m_query) {
+    wildcard_queries.clear();
+    if (Py_None == py_wildcard_queries) {
+        return true;
+    }
+
+    if (false == static_cast<bool>(PyObject_TypeCheck(py_wildcard_queries, &PyList_Type))) {
+        PyErr_SetString(
+                PyExc_TypeError,
+                get_c_str_from_constexpr_string_view(clp_ffi_py::cPyTypeError)
+        );
+        return false;
+    }
+
+    auto const wildcard_queries_size{PyList_Size(py_wildcard_queries)};
+    wildcard_queries.reserve(wildcard_queries_size);
+    for (Py_ssize_t idx{0}; idx < wildcard_queries_size; ++idx) {
+        auto* wildcard_query{PyList_GetItem(py_wildcard_queries, idx)};
+        if (1 != PyObject_IsInstance(wildcard_query, PyQuery::get_py_wildcard_query_type())) {
             PyErr_SetString(
-                    PyExc_RuntimeError,
-                    get_c_str_from_constexpr_string_view(clp_ffi_py::cOutOfMemoryError)
+                    PyExc_TypeError,
+                    get_c_str_from_constexpr_string_view(clp_ffi_py::cPyTypeError)
             );
             return false;
         }
-    } catch (clp_ffi_py::ExceptionFFI& ex) {
-        handle_traceable_exception(ex);
-        m_query = nullptr;
-        return false;
+        auto* wildcard_query_py_str{PyObject_GetAttrString(wildcard_query, "wildcard_query")};
+        if (nullptr == wildcard_query_py_str) {
+            return false;
+        }
+        auto* case_sensitive_py_bool{PyObject_GetAttrString(wildcard_query, "case_sensitive")};
+        if (nullptr == case_sensitive_py_bool) {
+            return false;
+        }
+        std::string_view wildcard_query_view;
+        if (false == parse_py_string_as_string_view(wildcard_query_py_str, wildcard_query_view)) {
+            return false;
+        }
+        int const is_case_sensitive{PyObject_IsTrue(case_sensitive_py_bool)};
+        if (-1 == is_case_sensitive && nullptr != PyErr_Occurred()) {
+            return false;
+        }
+        wildcard_queries.emplace_back(
+                clp::string_utils::clean_up_wildcard_search_string(wildcard_query_view),
+                static_cast<bool>(is_case_sensitive)
+        );
     }
     return true;
 }
 
-PyObjectStaticPtr<PyTypeObject> PyQuery::m_py_type{nullptr};
-PyObjectStaticPtr<PyObject> PyQuery::m_py_wildcard_query_type{nullptr};
-PyObjectStaticPtr<PyObject> PyQuery::m_py_full_string_wildcard_query_type{nullptr};
+auto serialize_wildcard_queries(std::vector<WildcardQuery> const& wildcard_queries) -> PyObject* {
+    Py_ssize_t const wildcard_queries_size{static_cast<Py_ssize_t>(wildcard_queries.size())};
+    if (0 == wildcard_queries_size) {
+        Py_RETURN_NONE;
+    }
+
+    auto* py_wildcard_queries{PyList_New(wildcard_queries_size)};
+    if (nullptr == py_wildcard_queries) {
+        return nullptr;
+    }
+
+    // In case of failure, we only need to decrement the reference for the Python list. CPython will
+    // decrement the reference count of all the objects it contains.
+    Py_ssize_t idx{0};
+    for (auto const& wildcard_query : wildcard_queries) {
+        PyObjectPtr<PyObject> const wildcard_py_str_ptr{
+                PyUnicode_FromString(wildcard_query.get_wildcard_query().c_str())
+        };
+        auto* wildcard_py_str{wildcard_py_str_ptr.get()};
+        if (nullptr == wildcard_py_str) {
+            Py_DECREF(py_wildcard_queries);
+            return nullptr;
+        }
+        PyObjectPtr<PyObject> const is_case_sensitive{get_py_bool(wildcard_query.is_case_sensitive()
+        )};
+        PyObject* py_wildcard_query{PyObject_CallFunction(
+                PyQuery::get_py_full_string_wildcard_query_type(),
+                "OO",
+                wildcard_py_str,
+                is_case_sensitive.get()
+        )};
+        if (nullptr == py_wildcard_query) {
+            Py_DECREF(py_wildcard_queries);
+            return nullptr;
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        PyList_SET_ITEM(py_wildcard_queries, idx, py_wildcard_query);
+        ++idx;
+    }
+    return py_wildcard_queries;
+}
+}  // namespace
 
 auto PyQuery::get_py_type() -> PyTypeObject* {
     return m_py_type.get();
@@ -692,6 +670,34 @@ auto PyQuery::module_level_init(PyObject* py_module) -> bool {
         return false;
     }
     m_py_full_string_wildcard_query_type.reset(py_full_string_wildcard_query_type);
+    return true;
+}
+
+auto PyQuery::init(
+        clp::ir::epoch_time_ms_t search_time_lower_bound,
+        clp::ir::epoch_time_ms_t search_time_upper_bound,
+        std::vector<WildcardQuery> const& wildcard_queries,
+        clp::ir::epoch_time_ms_t search_time_termination_margin
+) -> bool {
+    try {
+        // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+        m_query = new (std::nothrow)
+                Query(search_time_lower_bound,
+                      search_time_upper_bound,
+                      wildcard_queries,
+                      search_time_termination_margin);
+        if (nullptr == m_query) {
+            PyErr_SetString(
+                    PyExc_RuntimeError,
+                    get_c_str_from_constexpr_string_view(clp_ffi_py::cOutOfMemoryError)
+            );
+            return false;
+        }
+    } catch (clp_ffi_py::ExceptionFFI& ex) {
+        handle_traceable_exception(ex);
+        m_query = nullptr;
+        return false;
+    }
     return true;
 }
 }  // namespace clp_ffi_py::ir::native

--- a/src/clp_ffi_py/ir/native/PyQuery.hpp
+++ b/src/clp_ffi_py/ir/native/PyQuery.hpp
@@ -3,6 +3,10 @@
 
 #include <wrapped_facade_headers/Python.hpp>  // Must be included before any other header files
 
+#include <vector>
+
+#include <clp/ir/types.hpp>
+
 #include <clp_ffi_py/ir/native/Query.hpp>
 #include <clp_ffi_py/PyObjectUtils.hpp>
 
@@ -14,6 +18,47 @@ namespace clp_ffi_py::ir::native {
  */
 class PyQuery {
 public:
+    // Static methods
+    /**
+     * Gets the PyTypeObject that represents PyQuery's Python type. This type is dynamically created
+     * and initialized during the execution of `PyQuery::module_level_init`.
+     * @return Python type object associated with PyQuery.
+     */
+    [[nodiscard]] static auto get_py_type() -> PyTypeObject*;
+
+    /**
+     * Creates and initializes PyQuery as a Python type, and then incorporates this type as a Python
+     * object into the py_module module.
+     * @param py_module This is the Python module where the initialized PyQuery will be
+     * incorporated.
+     * @return true on success.
+     * @return false on failure with the relevant Python exception and error set.
+     */
+    [[nodiscard]] static auto module_level_init(PyObject* py_module) -> bool;
+
+    /**
+     * @return PyObject that represents the Python level class `WildcardQuery`.
+     */
+    [[nodiscard]] static auto get_py_wildcard_query_type() -> PyObject*;
+
+    /**
+     * @return PyObject that represents the Python level class `FullStringWildcardQuery`.
+     */
+    [[nodiscard]] static auto get_py_full_string_wildcard_query_type() -> PyObject*;
+
+    // Delete default constructor to disable direct instantiation.
+    PyQuery() = delete;
+
+    // Delete copy & move constructors and assignment operators
+    PyQuery(PyQuery const&) = delete;
+    PyQuery(PyQuery&&) = delete;
+    auto operator=(PyQuery const&) -> PyQuery& = delete;
+    auto operator=(PyQuery&&) -> PyQuery& = delete;
+
+    // Destructor
+    ~PyQuery() = default;
+
+    // Methods
     /**
      * Initializes the underlying data with the given input. Since the memory allocation of PyQuery
      * is handled by CPython's allocator, any cpp constructor will not be explicitly called. This
@@ -48,40 +93,13 @@ public:
 
     [[nodiscard]] auto get_query() -> Query* { return m_query; }
 
-    /**
-     * Gets the PyTypeObject that represents PyQuery's Python type. This type is dynamically created
-     * and initialized during the execution of `PyQuery::module_level_init`.
-     * @return Python type object associated with PyQuery.
-     */
-    [[nodiscard]] static auto get_py_type() -> PyTypeObject*;
-
-    /**
-     * Creates and initializes PyQuery as a Python type, and then incorporates this type as a Python
-     * object into the py_module module.
-     * @param py_module This is the Python module where the initialized PyQuery will be
-     * incorporated.
-     * @return true on success.
-     * @return false on failure with the relevant Python exception and error set.
-     */
-    [[nodiscard]] static auto module_level_init(PyObject* py_module) -> bool;
-
-    /**
-     * @return PyObject that represents the Python level class `WildcardQuery`.
-     */
-    [[nodiscard]] static auto get_py_wildcard_query_type() -> PyObject*;
-
-    /**
-     * @return PyObject that represents the Python level class `FullStringWildcardQuery`.
-     */
-    [[nodiscard]] static auto get_py_full_string_wildcard_query_type() -> PyObject*;
-
 private:
+    static inline PyObjectStaticPtr<PyTypeObject> m_py_type{nullptr};
+    static inline PyObjectStaticPtr<PyObject> m_py_wildcard_query_type{nullptr};
+    static inline PyObjectStaticPtr<PyObject> m_py_full_string_wildcard_query_type{nullptr};
+
     PyObject_HEAD;
     Query* m_query;
-
-    static PyObjectStaticPtr<PyTypeObject> m_py_type;
-    static PyObjectStaticPtr<PyObject> m_py_wildcard_query_type;
-    static PyObjectStaticPtr<PyObject> m_py_full_string_wildcard_query_type;
 };
 }  // namespace clp_ffi_py::ir::native
 

--- a/src/wrapped_facade_headers/Python.hpp
+++ b/src/wrapped_facade_headers/Python.hpp
@@ -22,6 +22,7 @@
 #include <dictobject.h>
 #include <floatobject.h>
 #include <import.h>
+#include <listobject.h>
 #include <longobject.h>
 #include <memoryobject.h>
 #include <methodobject.h>


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
NOTE: This PR depends on #116 to fix the cmake formatting issue.
This is one of the PR series trying to implement #96.
This PR fixes all clang-tidy warnings in `PyQuery`. Other than that, it also fixes the following problem:
- Correct the ordering of class member declaration (and fix the implementation ordering accordingly)
- Use API decoration instead of using extern "C" block explicitly
- Ensure local helper functions are declared before definitions
- Replace `constexpr const char*` by `constexpr std::string_view`

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure workflows all passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced static code analysis by adding new source files to the linting process.
	- Expanded `PyQuery` class functionality with new methods for Python integration.
	- Added support for serialization and deserialization of `PyQuery` objects.

- **Improvements**
	- Refined error handling and memory management for `PyQuery` class.
	- Updated method signatures to improve Python interoperability.
	- Added docstrings and improved code documentation.

- **Chores**
	- Updated build configuration for simplified syntax in library definition.
	- Modified header inclusions for better Python C API support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->