### PR TITLE
refactor: Update cmake file to fix the latest linting workflow failures.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,7 @@ find_package(
 )
 
 set(CLP_FFI_PY_LIB_IR "native")
-python_add_library(
-    ${CLP_FFI_PY_LIB_IR}
-    MODULE
-    WITH_SOABI
-)
+python_add_library(${CLP_FFI_PY_LIB_IR} MODULE WITH_SOABI)
 
 target_compile_features(${CLP_FFI_PY_LIB_IR} PRIVATE cxx_std_20)
 


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The recent linting workflow failed: https://github.com/y-scope/clp-ffi-py/actions/runs/12717785623/job/35454938209?pr=115
This is because the cmake formatter has been updated. This PR updates the cmake with the latest formatter.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure workflows all passed.

