### PR TITLE
refactor: Fix clang-tidy warnings in `Query`.

### DIFF
--- a/lint-tasks.yml
+++ b/lint-tasks.yml
@@ -127,6 +127,8 @@ tasks:
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PyQuery.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PySerializer.cpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/PySerializer.hpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/Query.cpp"
+            - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/ir/native/Query.hpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/modules"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.cpp"
             - "{{.CLP_FFI_PY_CPP_SRC_DIR}}/Py_utils.hpp"

--- a/src/clp_ffi_py/ir/native/Query.cpp
+++ b/src/clp_ffi_py/ir/native/Query.cpp
@@ -10,16 +10,12 @@ auto Query::matches_wildcard_queries(std::string_view log_message) const -> bool
     if (m_wildcard_queries.empty()) {
         return true;
     }
-    return std::any_of(
-            m_wildcard_queries.begin(),
-            m_wildcard_queries.end(),
-            [&](auto const& wildcard_query) {
-                return clp::string_utils::wildcard_match_unsafe(
-                        log_message,
-                        wildcard_query.get_wildcard_query(),
-                        wildcard_query.is_case_sensitive()
-                );
-            }
-    );
+    return std::ranges::any_of(m_wildcard_queries, [&](auto const& wildcard_query) {
+        return clp::string_utils::wildcard_match_unsafe(
+                log_message,
+                wildcard_query.get_wildcard_query(),
+                wildcard_query.is_case_sensitive()
+        );
+    });
 }
 }  // namespace clp_ffi_py::ir::native

--- a/src/clp_ffi_py/ir/native/Query.hpp
+++ b/src/clp_ffi_py/ir/native/Query.hpp
@@ -4,10 +4,11 @@
 #include <limits>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <clp/ErrorCode.hpp>
-#include <clp/ffi/encoding_methods.hpp>
+#include <clp/ir/types.hpp>
 
 #include <clp_ffi_py/ExceptionFFI.hpp>
 #include <clp_ffi_py/ir/native/LogEvent.hpp>


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This is one of the PR series trying to implement #96.
This PR fixes all clang-tidy warnings in `Query`.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure all workflows passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated static code analysis configuration to include new source files for linting
	- Modernized C++ code by updating header includes and using ranges-based algorithm

- **Refactor**
	- Simplified wildcard query matching implementation using C++ ranges

The changes focus on improving code quality and maintainability without altering core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->