### PR TITLE
refactor: Update cmake file to fix the latest linting workflow failures.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,10 +168,5 @@ target_link_libraries(
 )
 
 if(CLP_FFI_PY_INSTALL_LIBS)
-    install(
-        TARGETS
-            ${CLP_FFI_PY_LIB_IR}
-            DESTINATION
-            ${CLP_FFI_PY_PROJECT_NAME}/ir
-    )
+    install(TARGETS ${CLP_FFI_PY_LIB_IR} DESTINATION ${CLP_FFI_PY_PROJECT_NAME}/ir)
 endif()


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The recent linting workflow failed: https://github.com/y-scope/clp-ffi-py/actions/runs/12776276026/job/35614578961
This is because the cmake formatter has been updated. This PR updates the cmake with the latest formatter.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure all workflows passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Simplified the `CMakeLists.txt` file by condensing the `install` command syntax
	- No functional changes to the build configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->