### PR TITLE
fix(PyKeyValuePairLogEvent): Ensure proper `Py_None` reference count management when inserting into Python dictionaries (fixes #128).

### DIFF
--- a/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.cpp
+++ b/src/clp_ffi_py/ir/native/PyKeyValuePairLogEvent.cpp
@@ -621,7 +621,7 @@ auto serialize_node_id_value_pair_to_py_dict(
             break;
         }
         case SchemaTree::Node::Type::Obj:
-            py_value.reset(Py_None);
+            py_value.reset(get_new_ref_to_py_none());
             break;
         default:
             PyErr_Format(

--- a/src/clp_ffi_py/ir/native/deserialization_methods.cpp
+++ b/src/clp_ffi_py/ir/native/deserialization_methods.cpp
@@ -91,14 +91,10 @@ template <TerminateHandlerSignature TerminateHandler>
         TerminateHandler terminate_handler
 ) -> PyObject*;
 
-/**
- * @return A new reference to `Py_None`.
- */
-[[nodiscard]] auto get_new_ref_to_py_none() -> PyObject*;
-
-auto
-handle_incomplete_ir_error(PyDeserializerBuffer* deserializer_buffer, bool allow_incomplete_stream)
-        -> std::optional<PyObject*> {
+auto handle_incomplete_ir_error(
+        PyDeserializerBuffer* deserializer_buffer,
+        bool allow_incomplete_stream
+) -> std::optional<PyObject*> {
     if (deserializer_buffer->try_read()) {
         return std::nullopt;
     }
@@ -196,12 +192,6 @@ auto deserialize_log_events(
 
     return return_value;
 }
-
-auto get_new_ref_to_py_none() -> PyObject* {
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
 }  // namespace
 
 CLP_FFI_PY_METHOD auto

--- a/src/clp_ffi_py/ir/native/deserialization_methods.cpp
+++ b/src/clp_ffi_py/ir/native/deserialization_methods.cpp
@@ -91,10 +91,9 @@ template <TerminateHandlerSignature TerminateHandler>
         TerminateHandler terminate_handler
 ) -> PyObject*;
 
-auto handle_incomplete_ir_error(
-        PyDeserializerBuffer* deserializer_buffer,
-        bool allow_incomplete_stream
-) -> std::optional<PyObject*> {
+auto
+handle_incomplete_ir_error(PyDeserializerBuffer* deserializer_buffer, bool allow_incomplete_stream)
+        -> std::optional<PyObject*> {
     if (deserializer_buffer->try_read()) {
         return std::nullopt;
     }

--- a/src/clp_ffi_py/utils.cpp
+++ b/src/clp_ffi_py/utils.cpp
@@ -99,4 +99,9 @@ auto handle_traceable_exception(clp::TraceableException& exception) noexcept -> 
 auto construct_py_str_from_string_view(std::string_view sv) -> PyObject* {
     return PyUnicode_FromStringAndSize(sv.data(), static_cast<Py_ssize_t>(sv.size()));
 }
+
+auto get_new_ref_to_py_none() -> PyObject* {
+    Py_INCREF(Py_None);
+    return Py_None;
+}
 }  // namespace clp_ffi_py

--- a/src/clp_ffi_py/utils.hpp
+++ b/src/clp_ffi_py/utils.hpp
@@ -104,6 +104,11 @@ template <typename T>
 [[nodiscard]] consteval auto get_c_str_from_constexpr_string_view(std::string_view const& sv)
         -> char const*;
 
+/**
+ * @return A new reference to `Py_None`.
+ */
+[[nodiscard]] auto get_new_ref_to_py_none() -> PyObject*;
+
 template <clp::IntegerType IntType>
 auto parse_py_int(PyObject* py_int, IntType& val) -> bool {
     if (false == static_cast<bool>(PyLong_Check(py_int))) {


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR fixes the bug explained in #128.
In terms of maintainability, we move `get_new_ref_to_py_none` to `utils.hpp`.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure the bug has been fixed after applying this PR.
- Ensure all workflows passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
	- Improved Python `None` object reference management
	- Added utility function to handle `None` object references more efficiently
	- Streamlined code by removing redundant reference management function

- **Chores**
	- Updated internal utility methods for Python object handling

The changes focus on optimizing memory management and reference counting for Python objects, with minimal impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->