### PR TITLE
chore: Use environment markers to conditionally set msgpack version for Python3.7 compatibility.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ requires-python = ">=3.7"
 dependencies = [
     "Deprecated >= 1.2.14",
     # We lock msgpack to 1.0.5 to support Python3.7
-    "msgpack == 1.0.5",
+    "msgpack >= 1.1.0; python_version >= '3.8'",
+    "msgpack == 1.0.5; python_version < '3.8'",
     "python-dateutil >= 2.7.0",
     "typing-extensions >= 4.1.1",
     "zstandard >= 0.18.0",


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Before this PR, we lock the msgpack version to 1.0.5 for Python3.7 compatibility.
This PR uses an [environment marker](https://peps.python.org/pep-0496/) to lock msgpack version only for Python version < 3.8. For Python3.8 and later, we will use the latest version instead.
The type stub package doesn't need an update.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
- Ensure all workflows passed.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency management for the msgpack package to ensure improved compatibility. The package now uses version 1.1.0 or later for Python 3.8 and above, while maintaining version 1.0.5 for earlier Python versions. Users will benefit from more reliable dependency resolution based on their Python environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->